### PR TITLE
reflecting catalog naming changes

### DIFF
--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -86,7 +86,7 @@ class AlphaQClusterCatalog(AlphaQGalaxyCatalog):
     This class offers filtering on any halo quantity (group attribute), as seen in all three of the
     methods of this class (all the group attributes are iterated over in contexts concerning the
     pre-filtering). The valid filtering quantities are:
-    {'fof_halo_mass', 'sod_halo_cdelta', 'sod_halo_cdelta_error', 'sod_halo_c_acc_mass',
+    {'host_halo_mass', 'sod_halo_cdelta', 'sod_halo_cdelta_error', 'sod_halo_c_acc_mass',
      'fof_halo_tag', 'halo_index', 'halo_step', 'halo_ra', 'halo_dec', 'halo_z',
      'halo_z_err', 'sod_halo_radius', 'sod_halo_mass', 'sod_halo_ke', 'sod_halo_vel_disp'}
     """

--- a/GCRCatalogs/catalog_configs/proto-dc2-clusters-v1.0.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2-clusters-v1.0.yaml
@@ -1,5 +1,7 @@
 subclass_name: AlphaQClusterCatalog
 
-filename: /global/projecta/projectdirs/lsst/groups/CS/descqa/catalog/AlphaQv2_SDSSugrizbJROval42_mock_clusters.hdf5
+filename: /global/projecta/projectdirs/lsst/groups/CS/descqa/catalog/ANL_AlphaQ_SDSS_v42_clusters.hdf5
+
+lightcone: true
 
 creators: ['Eve Kovacs', 'Danila Korytov', 'Katrin Heitmann', 'Joe Hollowed']   

--- a/GCRCatalogs/catalog_configs/proto-dc2-v1.0.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2-v1.0.yaml
@@ -1,6 +1,6 @@
 subclass_name: AlphaQGalaxyCatalog
 
-filename: /global/projecta/projectdirs/lsst/groups/CS/descqa/catalog/AlphaQv2_SDSSugrizbJROval42_mock.hdf5
+filename: /global/projecta/projectdirs/lsst/groups/CS/descqa/catalog/ANL_AlphaQ_SDSS_v42.hdf5
 
 lightcone: true
 


### PR DESCRIPTION
A variable name has been changed in the catalog (the fof_halo_mass is now host_halo_mass), and the doc strings here have been updated for consistency. The .yaml files also now point to the most up-to-date catalogs on Cori.