### PR TITLE
use future to make iterator python 2 compatible

### DIFF
--- a/GCRCatSimInterface/DatabaseEmulator.py
+++ b/GCRCatSimInterface/DatabaseEmulator.py
@@ -1,7 +1,8 @@
 """
 This script will define classes that enable CatSim to interface with GCR
 """
-
+from future.builtins import next
+from future.builtins import object
 from collections import OrderedDict
 import numpy as np
 import gc


### PR DESCRIPTION
without this, the GCRCatSimInterface does not work in python 2