### PR TITLE
convert galaxy major and minor axis values from radians to arcseconds

### DIFF
--- a/GCRCatSimInterface/CatalogClasses.py
+++ b/GCRCatSimInterface/CatalogClasses.py
@@ -5,6 +5,7 @@ from lsst.utils import getPackageDir
 from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogSersic2D
 from lsst.sims.catalogs.decorators import cached, compound
 from lsst.sims.catUtils.mixins import EBVmixin
+from lsst.sims.utils import arcsecFromRadians
 
 __all__ = ["PhoSimDESCQA"]
 
@@ -144,3 +145,7 @@ class PhoSimDESCQA(PhoSimCatalogSersic2D, EBVmixin):
         """
         return self.column_by_name('fittedMagNorm')
 
+    def column_by_name(self, colname):
+        if colname in ('majorAxis', 'minorAxis'):
+            return arcsecFromRadians(super(PhoSimDESCQA, self).column_by_name(colname))
+        return super(PhoSimDESCQA, self).column_by_name(colname)


### PR DESCRIPTION
@danielsf Please have a look at https://github.com/LSSTDESC/DC2_Repo/issues/69#issuecomment-353740767  The changes in this PR seem to produce the correct output for protoDC2, but from looking over the sims code in various places, I'm wondering if the issue doesn't lie somewhere else in gcr-catalogs or in the catalog data.