### PR TITLE
Add stellar masses for disk/bulge (fixes #72)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_script:
 
 script:
 - nosetests tests/test_import.py
-- '[ -z "$CHANGED" ] || pylint --disable=C0103,C0301 --extension-pkg-whitelist=numpy $CHANGED; EXITCODE=$?; if [ $(($EXITCODE&7)) -gt 0 ]; then exit $EXITCODE; fi;
+- '[ -z "$CHANGED" ] || pylint --disable=C0103,C0301 --extension-pkg-whitelist=numpy $CHANGED; EXITCODE=$?; if [ $(($EXITCODE&7)) -gt 0 ]; then exit $EXITCODE; fi;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 before_install:
 - sudo apt-get -qq update
 - sudo apt-get install -y freetds-dev
-  
+
 install:
 - pip install .[full]
 - pip install pylint nose
@@ -17,4 +17,4 @@ before_script:
 
 script:
 - nosetests tests/test_import.py
-- '[ -z "$CHANGED" ] || pylint --disable=C0103,C0301 --extension-pkg-whitelist=numpy $CHANGED'
+- '[ -z "$CHANGED" ] || pylint --disable=C0103,C0301 --extension-pkg-whitelist=numpy $CHANGED; EXITCODE=$?; if [ $(($EXITCODE&7)) -gt 0 ]; then exit $EXITCODE; fi;

--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -63,8 +63,8 @@ Quantity Label | Unit | Definition
 `halo_id` | - | Unique ID of the main halo that contains the galaxy
 `halo_mass` | M<sub>sun</sub> | Halo mass of the main halo that contains the galaxy
 `stellar_mass` | M<sub>sun</sub> | Total stellar mass of the galaxy
-`stellar_mass_disk` | M<sub>sun</sub> | Total stellar mass of the disk component
-`stellar_mass_bulge` | M<sub>sun</sub> | Total stellar mass of the bulge component
+`stellar_mass_disk` | M<sub>sun</sub> | Stellar mass of the disk component
+`stellar_mass_bulge` | M<sub>sun</sub> | Stellar mass of the bulge component
 `is_central` | *(bool)* | If the galaxy is the central galaxy of the main halo
 `position_x` | Mpc | 3D position (x coordinate)
 `position_y` | Mpc | 3D position (y coordinate)

--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -63,6 +63,8 @@ Quantity Label | Unit | Definition
 `halo_id` | - | Unique ID of the main halo that contains the galaxy
 `halo_mass` | M<sub>sun</sub> | Halo mass of the main halo that contains the galaxy
 `stellar_mass` | M<sub>sun</sub> | Total stellar mass of the galaxy
+`stellar_mass_disk` | M<sub>sun</sub> | Total stellar mass of the disk component
+`stellar_mass_bulge` | M<sub>sun</sub> | Total stellar mass of the bulge component
 `is_central` | *(bool)* | If the galaxy is the central galaxy of the main halo
 `position_x` | Mpc | 3D position (x coordinate)
 `position_y` | Mpc | 3D position (y coordinate)

--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -33,7 +33,7 @@ class AlphaQGalaxyCatalog(BaseGenericCatalog):
     defined by BaseGenericCatalog class.
     """
 
-    def _subclass_init(self, filename, **kwargs): # pylint: disable-msg=W0221,R0912,R0914
+    def _subclass_init(self, filename, **kwargs): # pylint: disable-msg=W0221
 
         assert os.path.isfile(filename), 'Catalog file {} does not exist'.format(filename)
         self._file = filename

--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -6,7 +6,7 @@ import os
 import re
 import warnings
 import hashlib
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion # pylint: disable=no-name-in-module,import-error
 import numpy as np
 import h5py
 from astropy.cosmology import FlatLambdaCDM


### PR DESCRIPTION
This PR adds stellar masses for disk/bulge to both the protoDC2 reader and the schema, and fixes #72. 

It also fixes a few PEP8 issue so that it can pass travis CI build. 