### PR TITLE
add minor-axis size and bulge-to-total ratio to protoDC2

### DIFF
--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -65,7 +65,7 @@ Quantity Label | Unit | Definition
 `stellar_mass` | M<sub>sun</sub> | Total stellar mass of the galaxy
 `stellar_mass_disk` | M<sub>sun</sub> | Stellar mass of the disk component
 `stellar_mass_bulge` | M<sub>sun</sub> | Stellar mass of the bulge component
-`bulge_to_total_ratio_i` | - | bulge-to-total luminosity ratio in *i* band
+`bulge_to_total_ratio_<band>` | - | bulge-to-total luminosity ratio in `<band>` (e.g., `bulge_to_total_ratio_i`)
 `is_central` | *(bool)* | If the galaxy is the central galaxy of the main halo
 `position_x` | Mpc | 3D position (x coordinate)
 `position_y` | Mpc | 3D position (y coordinate)

--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -65,6 +65,7 @@ Quantity Label | Unit | Definition
 `stellar_mass` | M<sub>sun</sub> | Total stellar mass of the galaxy
 `stellar_mass_disk` | M<sub>sun</sub> | Stellar mass of the disk component
 `stellar_mass_bulge` | M<sub>sun</sub> | Stellar mass of the bulge component
+`bulge_to_total_ratio_i` | - | bulge-to-total luminosity ratio in *i* band
 `is_central` | *(bool)* | If the galaxy is the central galaxy of the main halo
 `position_x` | Mpc | 3D position (x coordinate)
 `position_y` | Mpc | 3D position (y coordinate)

--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -16,6 +16,15 @@ __all__ = ['AlphaQGalaxyCatalog']
 __version__ = '2.1.2'
 
 
+def _calc_weighted_size(size1, size2, lum1, lum2):
+    return ((size1*lum1) + (size2*lum2)) / (lum1+lum2)
+
+
+def _calc_weighted_size_minor(size1, size2, lum1, lum2, ell):
+    size = _calc_weighted_size(size1, size2, lum1, lum2)
+    return size * (1.0 - ell) / (1.0 + ell)
+
+
 def md5(fname, chunk_size=65536):
     """
     generate MD5 sum for *fname*
@@ -119,11 +128,23 @@ class AlphaQGalaxyCatalog(BaseGenericCatalog):
             'ellipticity_1_bulge_true': 'morphology/spheroidEllipticity1',
             'ellipticity_2_bulge_true': 'morphology/spheroidEllipticity2',
             'size_true': (
-                lambda size1, size2, lum1, lum2: ((size1*lum1)+(size2*lum2))/(lum1+lum2),
+                _calc_weighted_size,
                 'morphology/diskMajorAxisArcsec',
                 'morphology/spheroidMinorAxisArcsec',
                 'LSST_filters/diskLuminositiesStellar:LSST_r:rest',
                 'LSST_filters/spheroidLuminositiesStellar:LSST_r:rest',
+            ),
+            'size_minor_true': (
+                _calc_weighted_size_minor,
+                'morphology/diskMajorAxisArcsec',
+                'morphology/spheroidMinorAxisArcsec',
+                'LSST_filters/diskLuminositiesStellar:LSST_r:rest',
+                'LSST_filters/spheroidLuminositiesStellar:LSST_r:rest',
+                'morphology/totalEllipticity',
+            ),
+            'bulge_to_total_ratio_i': (
+                lambda x, y: x/(x+y),
+                'SDSS_filters/spheroidLuminositiesStellar:SDSS_i:observed', 'SDSS_filters/diskLuminositiesStellar:SDSS_i:observed',
             ),
             'position_x': 'x',
             'position_y': 'y',

--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -130,14 +130,14 @@ class AlphaQGalaxyCatalog(BaseGenericCatalog):
             'size_true': (
                 _calc_weighted_size,
                 'morphology/diskMajorAxisArcsec',
-                'morphology/spheroidMinorAxisArcsec',
+                'morphology/spheroidMajorAxisArcsec',
                 'LSST_filters/diskLuminositiesStellar:LSST_r:rest',
                 'LSST_filters/spheroidLuminositiesStellar:LSST_r:rest',
             ),
             'size_minor_true': (
                 _calc_weighted_size_minor,
                 'morphology/diskMajorAxisArcsec',
-                'morphology/spheroidMinorAxisArcsec',
+                'morphology/spheroidMajorAxisArcsec',
                 'LSST_filters/diskLuminositiesStellar:LSST_r:rest',
                 'LSST_filters/spheroidLuminositiesStellar:LSST_r:rest',
                 'morphology/totalEllipticity',

--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -16,15 +16,6 @@ __all__ = ['AlphaQGalaxyCatalog']
 __version__ = '2.1.2'
 
 
-def _calc_weighted_size(size1, size2, lum1, lum2):
-    return ((size1*lum1) + (size2*lum2)) / (lum1+lum2)
-
-
-def _calc_weighted_size_minor(size1, size2, lum1, lum2, ell):
-    size = _calc_weighted_size(size1, size2, lum1, lum2)
-    return size * (1.0 - ell) / (1.0 + ell)
-
-
 def md5(fname, chunk_size=65536):
     """
     generate MD5 sum for *fname*
@@ -34,6 +25,15 @@ def md5(fname, chunk_size=65536):
         for chunk in iter(lambda: f.read(chunk_size), b''):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
+
+
+def _calc_weighted_size(size1, size2, lum1, lum2):
+    return ((size1*lum1) + (size2*lum2)) / (lum1+lum2)
+
+
+def _calc_weighted_size_minor(size1, size2, lum1, lum2, ell):
+    size = _calc_weighted_size(size1, size2, lum1, lum2)
+    return size * (1.0 - ell) / (1.0 + ell)
 
 
 def _calc_conv(mag, shear1, shear2):


### PR DESCRIPTION
This PR fixes #76. 

This PR adds `size_minor_true` to protoDC2 using `size_true` and `ellipticity_true`. 

This PR also adds `bulge_to_total_ratio_i` to protoDC2 and an entry `bulge_to_total_ratio_<band>` to the schema. (I'm not sure if this is the best way; ideas welcome). 

(cc'ing @EiffL)