### PR TITLE
changes for 4.7 reader

### DIFF
--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -13,7 +13,7 @@ from astropy.cosmology import FlatLambdaCDM
 from GCR import BaseGenericCatalog
 
 __all__ = ['AlphaQGalaxyCatalog']
-__version__ = '4.5.0'
+__version__ = '4.7.0'
 
 
 def md5(fname, chunk_size=65536):

--- a/GCRCatalogs/catalog_configs/proto-dc2_v4.7.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v4.7.yaml
@@ -1,0 +1,13 @@
+subclass_name: alphaq.AlphaQGalaxyCatalog
+
+filename: /global/projecta/projectdirs/lsst/groups/CS/descqa/catalog/v4.7.2substep.all.hdf5
+
+lightcone: true
+
+version: "4.7.0"
+
+creators: [ 'Andrew Benson', 'Andrew Hearin',  'Katrin Heitmann', 'Danila Korytov', 'Eve Kovacs']
+
+description: |
+    ProtoDC2 is a down-scaled version of the catalog to be generated for LSST-DESC DC2.
+    For a description of the catalog and the methods, please see https://goo.gl/fXDQwP


### PR DESCRIPTION
Here are requested changes for 4.7 reader. It has been tested for this descqa run:
https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-06-12_8&test=CLF_r
Changes are a new yaml file, and trivial change to version number in alphaq.py.
I worked from gcr master (which was at v4.5)