### PR TITLE
ra and dec should be in deg

### DIFF
--- a/GCRCatalogs/dc2_coadd.py
+++ b/GCRCatalogs/dc2_coadd.py
@@ -41,8 +41,8 @@ class DC2CoaddCatalog(BaseGenericCatalog):
         self._dataset_cache = dict()
 
         self._quantity_modifiers = {
-            'ra': 'coord_ra',
-            'dec': 'coord_dec',
+            'ra': (np.rad2deg, 'coord_ra'),
+            'dec': (np.rad2deg, 'coord_dec'),
         }
 
         for band in 'ugrizy':


### PR DESCRIPTION
Just noticed that `coord_ra` and `coord_dec` are in radian, so when mapped to `ra` and `dec`, a conversion should be applied. 

@djperrefort this is probably fixed in the PR you will be submitting. I'm submitting this PR to fix this first because I noticed this issue in one of the example notebooks. 