### PR TITLE
add mag_<band> as aliases for mag_<band>_lsst

### DIFF
--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -32,6 +32,9 @@ Quantity Label | Unit | Definition
 `mag_true_<band>_<filter>` | - | Apparent magnitude, not lensed, in `<band>` with  `<filter>`, e.g., `mag_true_Y_lsst`, `mag_true_g_des`
 `mag_<band>_<filter>` | - | Apparent magnitude, lensed, in `<band>` with  `<filter>`, e.g., `mag_Y_lsst`, `mag_g_des`
 `magerr_<band>_<filter>` | - | Error in apparent magnitude in `<band>` with  `<filter>`, e.g., `magerr_Y_lsst`, `magerr_g_des`
+`mag_<band>` | - | alias for `mag_<band>_lsst`
+`mag_true_<band>` | - | alias for `mag_true_<band>_lsst`
+`magerr_<band>` | - | alias for `magerr_<band>_lsst`
 `sersic` | - | Sersic index of galaxy light profile
 `sersic_disk` | - | Sersic index of disk light profile
 `sersic_bulge` | - | Sersic index of bulge light profile
@@ -101,25 +104,25 @@ The schema for DC2 Coadd Catalogs follow the following rules:
 
 Quantity Label | Unit | Definition
 --- | --- | ---
-`centroidX` | pixels | 2D centroid location (x coordinate). 
-`centroidY` | pixels | 2D centroid location (y coordinate). 
-`centroidX_err` | pixels | Error value for `centroidX`. 
-`centroidY_err` | pixels | Error value for `centroidY`. 
-`centroid_flag` | - | Flag for issues with `centroidX` and `centroidY`. 
-`psFlux_<band>_lsst` | nmgy | Point source model flux in `<band>.` 
-`psFlux_err_<band>_lsst` | nmgy | Error value for `psFlux_<band>_lsst`. 
-`psFlux_flag_<band>_lsst` | - | Flag for issues with `psFlux_<band>_lsst`. 
+`centroidX` | pixels | 2D centroid location (x coordinate).
+`centroidY` | pixels | 2D centroid location (y coordinate).
+`centroidX_err` | pixels | Error value for `centroidX`.
+`centroidY_err` | pixels | Error value for `centroidY`.
+`centroid_flag` | - | Flag for issues with `centroidX` and `centroidY`.
+`psFlux_<band>_lsst` | nmgy | Point source model flux in `<band>.`
+`psFlux_err_<band>_lsst` | nmgy | Error value for `psFlux_<band>_lsst`.
+`psFlux_flag_<band>_lsst` | - | Flag for issues with `psFlux_<band>_lsst`.
 `Ixx_<band>_lsst` | asec2 | Adaptive second moment of the source intensity in `<band>`.
-`Iyy_<band>_lsst` | asec2 | Adaptive second moment of the source intensity in `<band>`. 
-`Ixy_<band>_lsst` | asec2 | Adaptive second moment of the source intensity in `<band>`. 
-`IxxPSF_<band>_lsst` | asec2 | Adaptive second moment for the PSF  in `<band>`. 
-`IyyPSF_<band>_lsst` | asec2 | Adaptive second moment for the PSF  in `<band>`. 
-`IxyPSF_<band>_lsst` | asec2 | Adaptive second moment for the PSF  in `<band>`. 
-`I_flag_<band>_lsst` | - | Flag for issues with `Ixx_<band>_lsst`, `Ixx_<band>_lsst`, and `Ixx_<band>_lsst.` 
+`Iyy_<band>_lsst` | asec2 | Adaptive second moment of the source intensity in `<band>`.
+`Ixy_<band>_lsst` | asec2 | Adaptive second moment of the source intensity in `<band>`.
+`IxxPSF_<band>_lsst` | asec2 | Adaptive second moment for the PSF  in `<band>`.
+`IyyPSF_<band>_lsst` | asec2 | Adaptive second moment for the PSF  in `<band>`.
+`IxyPSF_<band>_lsst` | asec2 | Adaptive second moment for the PSF  in `<band>`.
+`I_flag_<band>_lsst` | - | Flag for issues with `Ixx_<band>_lsst`, `Ixx_<band>_lsst`, and `Ixx_<band>_lsst.`
 `mag_<band>_CModel` | mag | Apparent magnitude in `<band>`, fitted by CModel.
-`magerr_<band>_CModel` | mag | Error value for `mag_<band>_cmodel.` 
+`magerr_<band>_CModel` | mag | Error value for `mag_<band>_cmodel.`
 `SNR_<band>_CModel` | - | Signal to noise ratio for magnitude in `<band>`, fitted by CModel.
-` psf_fwhm_<band>` | pixels | The full width at half maximum of the PSF 
-`good` | - | Whether the source contains any corrupted pixels. 
-`I_flag` | - | Flag for issues with `Ixx`, `Iyy`, and `Ixy`. 
+` psf_fwhm_<band>` | pixels | The full width at half maximum of the PSF
+`good` | - | Whether the source contains any corrupted pixels.
+`I_flag` | - | Flag for issues with `Ixx`, `Iyy`, and `Ixy`.
 `blendedness` | - | measure of how flux is affected by neighbors: (1 - flux.child/flux.parent) (see 4.9.11 of [1705.06766](https://arxiv.org/abs/1705.06766))

--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -263,22 +263,24 @@ class AlphaQGalaxyCatalog(BaseGenericCatalog):
         # add magnitudes
         for band in 'ugrizyY':
             if band != 'y' and band != 'Y':
-                self._quantity_modifiers['mag_true_{}_sdss'.format(band)] = 'SDSS_filters/magnitude:SDSS_{}:observed:dustAtlas'.format(band)
-                self._quantity_modifiers['Mag_true_{}_sdss_z0'.format(band)] = 'SDSS_filters/magnitude:SDSS_{}:rest:dustAtlas'.format(band)
-                self._quantity_modifiers['mag_true_{}_sdss_no_host_extinction'.format(band)] = 'SDSS_filters/magnitude:SDSS_{}:observed'.format(band)
-                self._quantity_modifiers['Mag_true_{}_sdss_z0_no_host_extinction'.format(band)] = 'SDSS_filters/magnitude:SDSS_{}:rest'.format(band)
-            self._quantity_modifiers['mag_true_{}_lsst'.format(band)] = 'LSST_filters/magnitude:LSST_{}:observed:dustAtlas'.format(band.lower())
-            self._quantity_modifiers['Mag_true_{}_lsst_z0'.format(band)] = 'LSST_filters/magnitude:LSST_{}:rest:dustAtlas'.format(band.lower())
-            self._quantity_modifiers['mag_true_{}_lsst_no_host_extinction'.format(band)] = 'LSST_filters/magnitude:LSST_{}:observed'.format(band.lower())
-            self._quantity_modifiers['Mag_true_{}_lsst_z0_no_host_extinction'.format(band)] = 'LSST_filters/magnitude:LSST_{}:rest'.format(band.lower())
-
-        # add lensed magnitudes
-        for band in 'ugrizyY':
-            if band != 'y' and band != 'Y':
                 self._quantity_modifiers['mag_{}_sdss'.format(band)] = (_calc_lensed_magnitude, 'SDSS_filters/magnitude:SDSS_{}:observed:dustAtlas'.format(band), 'magnification',)
                 self._quantity_modifiers['mag_{}_sdss_no_host_extinction'.format(band)] = (_calc_lensed_magnitude, 'SDSS_filters/magnitude:SDSS_{}:observed'.format(band), 'magnification',)
+                self._quantity_modifiers['mag_true_{}_sdss'.format(band)] = 'SDSS_filters/magnitude:SDSS_{}:observed:dustAtlas'.format(band)
+                self._quantity_modifiers['mag_true_{}_sdss_no_host_extinction'.format(band)] = 'SDSS_filters/magnitude:SDSS_{}:observed'.format(band)
+                self._quantity_modifiers['Mag_true_{}_sdss_z0'.format(band)] = 'SDSS_filters/magnitude:SDSS_{}:rest:dustAtlas'.format(band)
+                self._quantity_modifiers['Mag_true_{}_sdss_z0_no_host_extinction'.format(band)] = 'SDSS_filters/magnitude:SDSS_{}:rest'.format(band)
+
             self._quantity_modifiers['mag_{}_lsst'.format(band)] = (_calc_lensed_magnitude, 'LSST_filters/magnitude:LSST_{}:observed:dustAtlas'.format(band.lower()), 'magnification',)
             self._quantity_modifiers['mag_{}_lsst_no_host_extinction'.format(band)] = (_calc_lensed_magnitude, 'LSST_filters/magnitude:LSST_{}:observed'.format(band.lower()), 'magnification',)
+            self._quantity_modifiers['mag_true_{}_lsst'.format(band)] = 'LSST_filters/magnitude:LSST_{}:observed:dustAtlas'.format(band.lower())
+            self._quantity_modifiers['mag_true_{}_lsst_no_host_extinction'.format(band)] = 'LSST_filters/magnitude:LSST_{}:observed'.format(band.lower())
+            self._quantity_modifiers['Mag_true_{}_lsst_z0'.format(band)] = 'LSST_filters/magnitude:LSST_{}:rest:dustAtlas'.format(band.lower())
+            self._quantity_modifiers['Mag_true_{}_lsst_z0_no_host_extinction'.format(band)] = 'LSST_filters/magnitude:LSST_{}:rest'.format(band.lower())
+
+            if band != 'Y':
+                self._quantity_modifiers['mag_{}'.format(band)] = self._quantity_modifiers['mag_{}_lsst'.format(band)]
+                self._quantity_modifiers['mag_true_{}'.format(band)] = self._quantity_modifiers['mag_true_{}_lsst'.format(band)]
+
 
         # add SEDs
         translate_component_name = {'total': '', 'disk': '_disk', 'spheroid': '_bulge'}
@@ -323,11 +325,11 @@ class AlphaQGalaxyCatalog(BaseGenericCatalog):
             for key in (
                 'size_minor_true',
                 'ellipticity_true',
-                'ellipticity_1_true', 
-                'ellipticity_2_true', 
-                'ellipticity_1_disk_true', 
-                'ellipticity_2_disk_true', 
-                'ellipticity_1_bulge_true', 
+                'ellipticity_1_true',
+                'ellipticity_2_true',
+                'ellipticity_1_disk_true',
+                'ellipticity_2_disk_true',
+                'ellipticity_1_bulge_true',
                 'ellipticity_2_bulge_true',
             ):
                 if key in self._quantity_modifiers:

--- a/GCRCatalogs/buzzard.py
+++ b/GCRCatalogs/buzzard.py
@@ -99,6 +99,8 @@ class BuzzardGalaxyCatalog(BaseGenericCatalog):
                     i -= 1
                 self._quantity_modifiers['Mag_true_{}_lsst_z0'.format(b)] = (_abs_mask_func, 'lsst/AMAG/{}'.format(i))
                 self._quantity_modifiers['mag_{}_lsst'.format(b)] = (_mask_func, 'lsst/OMAG/{}'.format(i))
+                if b != 'Y':
+                    self._quantity_modifiers['mag_{}'.format(b)] = self._quantity_modifiers['mag_{}_lsst'.format(b)]
                 if b != 'y' and b != 'Y':
                     self._quantity_modifiers['Mag_true_{}_sdss_z01'.format(b)] = (_abs_mask_func, 'truth/AMAG/{}'.format(i))
                     self._quantity_modifiers['mag_true_{}_stripe82'.format(b)] = (_mask_func, 'stripe82/TMAG/{}'.format(i))
@@ -172,6 +174,8 @@ class BuzzardGalaxyCatalog(BaseGenericCatalog):
                     i -= 1
                 self._quantity_modifiers['Mag_true_{}_lsst_z0'.format(b)] = (_abs_mask_func, 'lsst/AMAG/{}'.format(i))
                 self._quantity_modifiers['mag_true_{}_lsst'.format(b)] = (_mask_func, 'lsst/TMAG/{}'.format(i))
+                if b != 'Y':
+                    self._quantity_modifiers['mag_true_{}'.format(b)] = self._quantity_modifiers['mag_true_{}_lsst'.format(b)]
                 if b != 'u':
                     i -= 1
                     self._quantity_modifiers['Mag_true_{}_des_z01'.format(b)] = (_abs_mask_func, 'truth/AMAG/{}'.format(i))


### PR DESCRIPTION
This PR, together with #133, address #132.

We've decided that, when the filter postfix is not present, it falls back to `lsst` filter. 