### PR TITLE
Adds reader for HSC flat catalog

### DIFF
--- a/GCRCatalogs/catalog_configs/hsc-pdr1-xmm.yaml
+++ b/GCRCatalogs/catalog_configs/hsc-pdr1-xmm.yaml
@@ -1,0 +1,5 @@
+subclass_name: dc2_coadd.DC2CoaddCatalog
+base_dir: /global/cscratch1/sd/jchiang8/desc/HSC/
+description: XMM field of the HSC PDR1
+creators: ['Hyper Suprime-Cam (HSC) collaboration']
+included_by_default: true

--- a/GCRCatalogs/catalog_configs/hsc-pdr1-xmm.yaml
+++ b/GCRCatalogs/catalog_configs/hsc-pdr1-xmm.yaml
@@ -3,3 +3,4 @@ base_dir: /global/cscratch1/sd/jchiang8/desc/HSC/
 description: XMM field of the HSC PDR1
 creators: ['Hyper Suprime-Cam (HSC) collaboration']
 included_by_default: true
+pixel_scale=0.168

--- a/GCRCatalogs/catalog_configs/hsc-pdr1-xmm.yaml
+++ b/GCRCatalogs/catalog_configs/hsc-pdr1-xmm.yaml
@@ -1,6 +1,6 @@
 subclass_name: dc2_coadd.DC2CoaddCatalog
-base_dir: /global/cscratch1/sd/jchiang8/desc/HSC/
+base_dir: /global/cscratch1/sd/desc/hsc
 description: XMM field of the HSC PDR1
 creators: ['Hyper Suprime-Cam (HSC) collaboration']
 included_by_default: true
-pixel_scale=0.168
+pixel_scale: 0.168

--- a/GCRCatalogs/dc2_coadd.py
+++ b/GCRCatalogs/dc2_coadd.py
@@ -93,14 +93,16 @@ class DC2CoaddCatalog(BaseGenericCatalog):
 
         self._dataset_cache = dict()
 
-        self._quantity_modifiers = self._generate_modifiers(self.pixel_scale)
         self._datasets, self._columns = self._generate_datasets_and_columns()
         if not self._datasets:
             err_msg = 'No catalogs were found in `base_dir` {}'
             raise RuntimeError(err_msg.format(self._base_dir))
+        
+        bands = [col[0] for col in self._columns if len(col) == 5 and col.endswith('_mag')]
+        self._quantity_modifiers = self._generate_modifiers(self.pixel_scale, bands)
 
     @staticmethod
-    def _generate_modifiers(pixel_scale=0.2):
+    def _generate_modifiers(pixel_scale=0.2, bands='ugrizy'):
         """Creates a dictionary relating native and homogenized column names
 
         Returns:
@@ -144,7 +146,7 @@ class DC2CoaddCatalog(BaseGenericCatalog):
             modifiers['I{}'.format(ax)] = 'ext_shapeHSM_HsmSourceMoments_{}'.format(ax)
             modifiers['I{}PSF'.format(ax)] = 'base_SdssShape_psf_{}'.format(ax)
 
-        for band in 'ugrizy':
+        for band in bands:
             modifiers['mag_{}'.format(band)] = '{}_mag'.format(band)
             modifiers['magerr_{}'.format(band)] = '{}_mag_err'.format(band)
             modifiers['psFlux_{}'.format(band)] = '{}_base_PsfFlux_flux'.format(band)

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ You can also find an overview of the data products of DESC Data Challenge 2
 at [this Confluence page](https://confluence.slac.stanford.edu/x/oJgHDg)
 (*DESC member only*).
 
-1. "protoDC2" Extragalactic Catalogs:
-   by Andrew Benson, Andrew Hearin, Katrin Heitmann, Danila Korytov, Eve Kovacs et al.
+1. "protoDC2" Extragalactic Catalogs: \
+   *by Andrew Benson, Andrew Hearin, Katrin Heitmann, Danila Korytov, Eve Kovacs et al.*
    - `protoDC2` (full catalog)
    - `protoDC2_test` (same as `protoDC2` but this one skips time-consuming md5 check.)
    - `proto-dc2_vX.X_test.yaml` (some other versions of the protoDC2 catalog. You can run
@@ -40,30 +40,34 @@ at [this Confluence page](https://confluence.slac.stanford.edu/x/oJgHDg)
      ```
      to see all available versions.
 
-2. "Buzzard" Extragalactic Catalogs:
-   by Joe DeRose, Risa Wechsler, Eli Rykoff et al.
+2. "Buzzard" Extragalactic Catalogs: \
+   *by Joe DeRose, Risa Wechsler, Eli Rykoff et al.*
    - `buzzard` (full catalog, DES Y3 area)
    - `buzzard_test` (same as `buzzard` but a small subset for testing purpose / faster access)
    - `buzzard_high-res` (higher resolution, smaller sky area)
    - `buzzard_v1.6_1`, `buzzard_v1.6_2`, `buzzard_v1.6_3`, `buzzard_v1.6_5`, `buzzard_v1.6_21` (different realizations of `buzzard`)
 
-3. DC2 "Coadd Catalogs":
-   by LSST DESC, compiled by Michael Wood-Vasey
+3. DC2 "Coadd Catalogs": \
+   *by LSST DESC, compiled by Michael Wood-Vasey*
    - `dc2_coadd_run1.1p`: coadd catalog for Run 1.1p
    - `dc2_coadd_run1.1p_tract4850`: same as `dc2_coadd_run1.1p` but has only one tract (4850) for testing purpose / faster access
 
-4. DC2 "Reference Catalogs":
-   by LSST DESC, compiled by Scott Daniel
+4. DC2 "Reference Catalogs": \
+   *by LSST DESC, compiled by Scott Daniel*
    - `dc2_reference_run1.1p`: reference catalog for Run 1.1p
    - `dc2_reference_run1.2p`: reference catalog for Run 1.2p
 
-5. DC2 "Instance Catalogs":
-   by LSST DESC, compiled by Scott Daniel
+5. DC2 "Instance Catalogs": \
+   *by LSST DESC, compiled by Scott Daniel*
    - `dc2_instance_example1`: an example instance catalog
    - `dc2_instance_example2`: another example instance catalog
 
 6. DC1 Galaxy Catalog:
    - `dc1`: Galaxy catalog used for DC1 (also known as "the catalog on fatboy")
+
+7. HSC Coadd Catalog for PDR1 XMM field: \
+   *by the Hyper Suprime-Cam (HSC) Collaboration*
+   - `hsc-pdr1-xmm`
 
 
 ## Use GCRCatalogs at NERSC


### PR DESCRIPTION
This PR simply adds a configuration file which reuses the `DC2CoaddCatalog` to load the HSC coadd catalogs. Everything seems to work, except for the fact that we are missing the U-band. 
Do we want a different reader to handle this case, or should we adapt the DC2CoaddCatalog reader to not expose the u-band (or any band) if it's not available in the data ?

[edited by @yymao: this PR fixes #135]