### PR TITLE
update to v0.8.0-alpha

### DIFF
--- a/GCRCatalogs/version.py
+++ b/GCRCatalogs/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.7.8'
+__version__ = '0.8.0-alpha'


### PR DESCRIPTION
While there are still a few things to be done before we release v0.8.0, I'd like to tag and release `v0.8.0-alpha` and install it in the DESC shared environment, so that the tutorial writers can use it directly. 

What do you think @wmwv @heather999?