### PR TITLE
use string-like native filter as where conditions

### DIFF
--- a/GCRCatalogs/dc1.py
+++ b/GCRCatalogs/dc1.py
@@ -19,6 +19,8 @@ class DC1GalaxyCatalog(BaseGenericCatalog):
     """
     DC1 galaxy catalog class.
     """
+    
+    _allow_string_native_filter = True
 
     def _subclass_init(self, **kwargs):
 
@@ -79,7 +81,11 @@ class DC1GalaxyCatalog(BaseGenericCatalog):
 
     def _iter_native_dataset(self, native_filters=None):
         session = self._Session()
+        if native_filters:
+            condition = 'WHERE ' + ' AND '.join(native_filters)
+        else:
+            condition = ''
         def native_quantity_getter(native_quantity):
-            query = 'SELECT {} from galaxy'.format(native_quantity)
+            query = 'SELECT {} from galaxy {}'.format(native_quantity, condition)
             return np.array([r[0] for r in session.execute(query)])
         yield native_quantity_getter

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     keywords='GCR',
     packages=['GCRCatalogs'],
-    install_requires=['future', 'requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.6.2'],
+    install_requires=['future', 'requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.6.4'],
     extras_require = {
         'protodc2': ['h5py'],
         'instance': ['pandas'],


### PR DESCRIPTION
[GCR v0.6.4](https://github.com/yymao/generic-catalog-reader/releases/tag/v0.6.4) adds an `_allow_string_native_filter` option, which when enabled, the user can supply a list of WHERE statments in as `native_filters` in `get_quantities`. 

This PR utilizes this feature in the DC1 reader. 