### PR TITLE
correct clean definition (fix #136)

### DIFF
--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -134,8 +134,8 @@ Quantity Label | Unit | Definition | GCRbase | DPDD
 `magerr_<band>_cModel` | mag | Error value for `mag_<band>_cModel.` | x |   |
 `snr_<band>_cModel` | - | Signal to noise ratio for magnitude in `<band>`, fitted by cModel. |   |   |
 `psf_fwhm_<band>` | pixels | PSF FWHM calculated from 'base_SdssShape' |   |   |
-`good` | - | True if the source has no flagged pixels. |   |   |
-`clean` | - |  True if the source has no flagged pixels and is not deblended (`good && deblend_skipped`). |   |   |
+`clean` | - | True if the source has no flagged pixels. |   |   |
+`good` | - |  True if the source has no flagged pixels and is not deblended (`clean && deblend_skipped`). |   |   |
 `I_flag` | - | Flag for issues with `Ixx`, `Iyy`, and `Ixy`. |   | xx |
 `blendedness` | - | measure of how flux is affected by neighbors: (1 - flux.child/flux.parent) (see 4.9.11 of [1705.06766](https://arxiv.org/abs/1705.06766)) |   |   |
 `extendedness` | - | 0:star, 1:extended.  DM Stack `base_ClassificationExtendedness_value` |   |   |

--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -134,8 +134,8 @@ Quantity Label | Unit | Definition | GCRbase | DPDD
 `magerr_<band>_cModel` | mag | Error value for `mag_<band>_cModel.` | x |   |
 `snr_<band>_cModel` | - | Signal to noise ratio for magnitude in `<band>`, fitted by cModel. |   |   |
 `psf_fwhm_<band>` | pixels | PSF FWHM calculated from 'base_SdssShape' |   |   |
-`clean` | - | True if the source has no flagged pixels. |   |   |
-`good` | - |  True if the source has no flagged pixels and is not deblended (`clean && deblend_skipped`). |   |   |
+`good` | - | True if the source has no flagged pixels. |   |   |
+`clean` | - |  True if the source has no flagged pixels and is not deblended (`good && deblend_skipped`). |   |   |
 `I_flag` | - | Flag for issues with `Ixx`, `Iyy`, and `Ixy`. |   | xx |
 `blendedness` | - | measure of how flux is affected by neighbors: (1 - flux.child/flux.parent) (see 4.9.11 of [1705.06766](https://arxiv.org/abs/1705.06766)) |   |   |
 `extendedness` | - | 0:star, 1:extended.  DM Stack `base_ClassificationExtendedness_value` |   |   |

--- a/GCRCatalogs/dc2_coadd.py
+++ b/GCRCatalogs/dc2_coadd.py
@@ -43,7 +43,7 @@ def calc_cov(ixx_err, iyy_err, ixy_err):
     return out_data.transpose()
 
 
-def create_basic_flag_mask(*flags):
+def create_good_flag_mask(*flags):
     """
     generate a mask for a set of flags
     for each item, mask will be true if and only if all flags are false
@@ -123,7 +123,7 @@ class DC2CoaddCatalog(BaseGenericCatalog):
             'blendedness': 'base_Blendedness_abs_flux',
         }
 
-        not_clean_flags = (
+        not_good_flags = (
             'base_PixelFlags_flag_edge',
             'base_PixelFlags_flag_interpolatedCenter',
             'base_PixelFlags_flag_saturatedCenter',
@@ -133,12 +133,12 @@ class DC2CoaddCatalog(BaseGenericCatalog):
             'base_PixelFlags_flag_clipped',
         )
 
-        modifiers['clean'] = (create_basic_flag_mask,) + not_clean_flags
+        modifiers['good'] = (create_good_flag_mask,) + not_good_flags
 
-        modifiers['good'] = (
-            create_basic_flag_mask,
+        modifiers[''] = (
+            lambda x, *args: x.astype(np.bool) & create_good_flag_mask(args),
             'deblend_skipped',
-        ) + not_clean_flags
+        ) + not_good_flags
 
         # cross-band average, second moment values
         modifiers['I_flag'] = 'ext_shapeHSM_HsmSourceMoments_flag'

--- a/GCRCatalogs/dc2_coadd.py
+++ b/GCRCatalogs/dc2_coadd.py
@@ -97,7 +97,7 @@ class DC2CoaddCatalog(BaseGenericCatalog):
         if not self._datasets:
             err_msg = 'No catalogs were found in `base_dir` {}'
             raise RuntimeError(err_msg.format(self._base_dir))
-        
+
         bands = [col[0] for col in self._columns if len(col) == 5 and col.endswith('_mag')]
         self._quantity_modifiers = self._generate_modifiers(self.pixel_scale, bands)
 
@@ -123,7 +123,7 @@ class DC2CoaddCatalog(BaseGenericCatalog):
             'blendedness': 'base_Blendedness_abs_flux',
         }
 
-        not_good_flags = (
+        not_clean_flags = (
             'base_PixelFlags_flag_edge',
             'base_PixelFlags_flag_interpolatedCenter',
             'base_PixelFlags_flag_saturatedCenter',
@@ -133,12 +133,12 @@ class DC2CoaddCatalog(BaseGenericCatalog):
             'base_PixelFlags_flag_clipped',
         )
 
-        modifiers['good'] = (create_basic_flag_mask,) + not_good_flags
+        modifiers['clean'] = (create_basic_flag_mask,) + not_clean_flags
 
-        modifiers['clean'] = (
+        modifiers['good'] = (
             create_basic_flag_mask,
             'deblend_skipped',
-        ) + not_good_flags
+        ) + not_clean_flags
 
         # cross-band average, second moment values
         modifiers['I_flag'] = 'ext_shapeHSM_HsmSourceMoments_flag'


### PR DESCRIPTION
As @wmwv requested in #136, this PR seaps the definitions of `good` and `clean`. 

Obviously this will break backward compatibility. @EiffL @fjaviersanchez is this going to be a big headache for you?