### PR TITLE
make reader works with table format

### DIFF
--- a/GCRCatalogs/dc2_coadd.py
+++ b/GCRCatalogs/dc2_coadd.py
@@ -145,6 +145,7 @@ class DC2CoaddCatalog(BaseGenericCatalog):
         self._filename_re = re.compile(kwargs.get('filename_pattern', FILE_PATTERN))
         self._groupname_re = re.compile(kwargs.get('groupname_pattern', GROUP_PATTERN))
         self.pixel_scale = float(kwargs.get('pixel_scale', 0.2))
+        self.use_cache = bool(kwargs.get('use_cache', True))
 
         if not os.path.isdir(self.base_dir):
             raise ValueError('`base_dir` {} is not a valid directory'.format(self.base_dir))
@@ -304,6 +305,11 @@ class DC2CoaddCatalog(BaseGenericCatalog):
         """
         return sorted(set(dataset.tract for dataset in self._datasets))
 
+    def clear_cache(self):
+        """Empty the catalog reader cache and frees up memory allocation"""
+        for dataset in self._datasets:
+            dataset.clear_cache()
+
     def _open_hdf5(self, file_path):
         """Open an HDF5 file at *file_path* and return the file handle as an
         pd.HDFStore object (and cache the handle).
@@ -338,4 +344,5 @@ class DC2CoaddCatalog(BaseGenericCatalog):
                 return d[native_quantity]
 
             yield _native_quantity_getter
-            dataset.clear_cache()
+            if not self.use_cache:
+                dataset.clear_cache()

--- a/GCRCatalogs/dc2_coadd.py
+++ b/GCRCatalogs/dc2_coadd.py
@@ -69,6 +69,7 @@ class TableWrapper(object):
 
         self._columns = None
         self._len = None
+        self._fixed_data = None
 
     @property
     def columns(self):
@@ -97,7 +98,13 @@ class TableWrapper(object):
         if self.is_table:
             return self.storer.read(columns=[key])[key].values
 
-        return self.storer.read()[key].values
+        if self._fixed_data is None:
+            self._fixed_data = self.storer.read()
+
+        return self._fixed_data[key].values
+
+    def clear_cache(self):
+        self._fixed_data = None
 
 
 class CoaddTableWrapper(TableWrapper):
@@ -331,3 +338,4 @@ class DC2CoaddCatalog(BaseGenericCatalog):
                 return d[native_quantity]
 
             yield _native_quantity_getter
+            dataset.clear_cache()


### PR DESCRIPTION
OK this PR makes the coadd reader works with `table` hdf5 format to address #145  However, the reader is not yet optimized for `table` format. In particular, it still loads the whole table even when only a few columns are needed. 

To optimize the reader for the `table` format, a more significant change is needed. I'll continue to update this PR in the coming days.  

[Edited: This PR fixes #145]