### PR TITLE
update native_filters behavior for GCR 0.7.1

### DIFF
--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -349,7 +349,8 @@ class AlphaQGalaxyCatalog(BaseGenericCatalog):
 
 
     def _iter_native_dataset(self, native_filters=None):
-        assert not native_filters, '*native_filters* is not supported'
+        if native_filters is not None:
+            raise ValueError('*native_filters* is not supported')
         with h5py.File(self._file, 'r') as fh:
             def _native_quantity_getter(native_quantity):
                 return fh['galaxyProperties/{}'.format(native_quantity)].value # pylint: disable=no-member

--- a/GCRCatalogs/buzzard.py
+++ b/GCRCatalogs/buzzard.py
@@ -224,7 +224,7 @@ class BuzzardGalaxyCatalog(BaseGenericCatalog):
 
     def _iter_native_dataset(self, native_filters=None):
         for healpix in self.healpix_pixels:
-            if native_filters.check_scalar({'healpix_pixel': healpix}):
+            if native_filters is None or native_filters.check_scalar({'healpix_pixel': healpix}):
                 yield functools.partial(self._native_quantity_getter, healpix=healpix)
 
 

--- a/GCRCatalogs/buzzard.py
+++ b/GCRCatalogs/buzzard.py
@@ -224,12 +224,8 @@ class BuzzardGalaxyCatalog(BaseGenericCatalog):
 
     def _iter_native_dataset(self, native_filters=None):
         for healpix in self.healpix_pixels:
-
-            fargs = dict(healpix_pixel=healpix)
-            if native_filters and not all(f[0](*(fargs[k] for k in f[1:])) for f in native_filters):
-                continue
-
-            yield functools.partial(self._native_quantity_getter, healpix=healpix)
+            if native_filters.check_scalar({'healpix_pixel': healpix}):
+                yield functools.partial(self._native_quantity_getter, healpix=healpix)
 
 
     def _open_dataset(self, healpix, subset):

--- a/GCRCatalogs/dc1.py
+++ b/GCRCatalogs/dc1.py
@@ -20,7 +20,7 @@ class DC1GalaxyCatalog(BaseGenericCatalog):
     DC1 galaxy catalog class.
     """
     
-    _allow_string_native_filter = True
+    native_filter_string_only = True
 
     def _subclass_init(self, **kwargs):
 

--- a/GCRCatalogs/dc2_coadd.py
+++ b/GCRCatalogs/dc2_coadd.py
@@ -374,10 +374,7 @@ class DC2CoaddCatalog(BaseGenericCatalog):
     def _iter_native_dataset(self, native_filters=None):
         for dataset in self._datasets:
             dataset_info = self.get_dataset_info(dataset)
-            if native_filters and \
-                    not all(native_filter[0](
-                        *(dataset_info[c] for c in native_filter[1:])) \
-                            for native_filter in native_filters):
+            if not native_filters.check_scalar(dataset_info):
                 continue
 
             try:

--- a/GCRCatalogs/dc2_coadd.py
+++ b/GCRCatalogs/dc2_coadd.py
@@ -374,7 +374,8 @@ class DC2CoaddCatalog(BaseGenericCatalog):
     def _iter_native_dataset(self, native_filters=None):
         for dataset in self._datasets:
             dataset_info = self.get_dataset_info(dataset)
-            if not native_filters.check_scalar(dataset_info):
+            if native_filters is not None and \
+                    not native_filters.check_scalar(dataset_info):
                 continue
 
             try:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     keywords='GCR',
     packages=['GCRCatalogs'],
-    install_requires=['future', 'requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.7.0'],
+    install_requires=['future', 'requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.7.1'],
     extras_require = {
         'protodc2': ['h5py'],
         'instance': ['pandas'],

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     keywords='GCR',
     packages=['GCRCatalogs'],
-    install_requires=['future', 'requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.7.1'],
+    install_requires=['future', 'requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.7.2'],
     extras_require = {
         'protodc2': ['h5py'],
         'instance': ['pandas'],

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     keywords='GCR',
     packages=['GCRCatalogs'],
-    install_requires=['future', 'requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.6.4'],
+    install_requires=['future', 'requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.7.0'],
     extras_require = {
         'protodc2': ['h5py'],
         'instance': ['pandas'],


### PR DESCRIPTION
In GCR 0.7.x, one can use `native_filters.check_scalar` to check if a dict of scalar satisfies `native_filters`. This makes the code that checks `native_filters` much more readable. 

This also enables the users to write `native_filters` in string, for example: `native_filters=['tract == 4850']`. 

Note that in order to test this, you need GCR 0.7.1. 

cc @EiffL @danielsf  