### PR TITLE
update definition of `clean` in SCHEMA.md

### DIFF
--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -135,7 +135,7 @@ Quantity Label | Unit | Definition | GCRbase | DPDD
 `snr_<band>_cModel` | - | Signal to noise ratio for magnitude in `<band>`, fitted by cModel. |   |   |
 `psf_fwhm_<band>` | pixels | PSF FWHM calculated from 'base_SdssShape' |   |   |
 `good` | - | True if the source has no flagged pixels. |   |   |
-`clean` | - |  True if the source has no flagged pixels and is not deblended (`good && ~deblend_skipped`). |   |   |
+`clean` | - |  True if the source has no flagged pixels and is not skipped by the deblender (`good && ~deblend_skipped`). |   |   |
 `I_flag` | - | Flag for issues with `Ixx`, `Iyy`, and `Ixy`. |   | xx |
 `blendedness` | - | measure of how flux is affected by neighbors: (1 - flux.child/flux.parent) (see 4.9.11 of [1705.06766](https://arxiv.org/abs/1705.06766)) |   |   |
 `extendedness` | - | 0:star, 1:extended.  DM Stack `base_ClassificationExtendedness_value` |   |   |

--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -135,7 +135,7 @@ Quantity Label | Unit | Definition | GCRbase | DPDD
 `snr_<band>_cModel` | - | Signal to noise ratio for magnitude in `<band>`, fitted by cModel. |   |   |
 `psf_fwhm_<band>` | pixels | PSF FWHM calculated from 'base_SdssShape' |   |   |
 `good` | - | True if the source has no flagged pixels. |   |   |
-`clean` | - |  True if the source has no flagged pixels and is not deblended (`good && deblend_skipped`). |   |   |
+`clean` | - |  True if the source has no flagged pixels and is not deblended (`good && ~deblend_skipped`). |   |   |
 `I_flag` | - | Flag for issues with `Ixx`, `Iyy`, and `Ixy`. |   | xx |
 `blendedness` | - | measure of how flux is affected by neighbors: (1 - flux.child/flux.parent) (see 4.9.11 of [1705.06766](https://arxiv.org/abs/1705.06766)) |   |   |
 `extendedness` | - | 0:star, 1:extended.  DM Stack `base_ClassificationExtendedness_value` |   |   |


### PR DESCRIPTION
This PR updates the definition of `clean` in `SCHEMA.md` to make it consistent with the implementation. 