### PR TITLE
add sigma8 and n_s to the cosmology attribute

### DIFF
--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -132,6 +132,9 @@ class AlphaQGalaxyCatalog(BaseGenericCatalog):
                 Om0=fh['metaData/simulationParameters/Omega_matter'].value,
                 Ob0=fh['metaData/simulationParameters/Omega_b'].value,
             )
+            self.cosmology.sigma8 = fh['metaData/simulationParameters/sigma_8'].value
+            self.cosmology.n_s = fh['metaData/simulationParameters/N_s'].value
+            self.halo_mass_def = fh['metaData/simulationParameters/haloMassDefinition'].value
 
             # get sky area
             if catalog_version >= StrictVersion("2.1.1"):

--- a/GCRCatalogs/buzzard.py
+++ b/GCRCatalogs/buzzard.py
@@ -61,7 +61,13 @@ class BuzzardGalaxyCatalog(BaseGenericCatalog):
 
         self.cache = dict() if use_cache else None
 
-        self.cosmology = FlatLambdaCDM(**cosmology)
+        cosmo_astropy_allowed = FlatLambdaCDM.__init__.__code__.co_varnames[1:]
+        cosmo_astropy = {k: v for k, v in cosmology.items() if k in cosmo_astropy_allowed}
+        self.cosmology = FlatLambdaCDM(**cosmo_astropy)
+        for k, v in cosmology.items():
+            if k not in cosmo_astropy_allowed:
+                setattr(self.cosmology, k, v)
+
         self.halo_mass_def = halo_mass_def
         self.lightcone = bool(lightcone)
         self.sky_area  = float(sky_area or np.nan)

--- a/GCRCatalogs/catalog_configs/buzzard_high-res_v1.1.yaml
+++ b/GCRCatalogs/catalog_configs/buzzard_high-res_v1.1.yaml
@@ -26,6 +26,8 @@ cosmology:
     H0: 70.0
     Om0: 0.286
     Ob0: 0.047
+    sigma8: 0.82
+    n_s: 0.96
 
 halo_mass_def: vir
 lightcone: true

--- a/GCRCatalogs/catalog_configs/buzzard_v1.6.yaml
+++ b/GCRCatalogs/catalog_configs/buzzard_v1.6.yaml
@@ -9,6 +9,8 @@ cosmology:
     H0: 70.0
     Om0: 0.286
     Ob0: 0.047
+    sigma8: 0.82
+    n_s: 0.96
 
 halo_mass_def: vir
 lightcone: true

--- a/GCRCatalogs/catalog_configs/buzzard_v1.6_1.yaml
+++ b/GCRCatalogs/catalog_configs/buzzard_v1.6_1.yaml
@@ -8,6 +8,8 @@ cosmology:
     H0: 70.0
     Om0: 0.286
     Ob0: 0.047
+    sigma8: 0.82
+    n_s: 0.96
 
 halo_mass_def: vir
 lightcone: true

--- a/GCRCatalogs/catalog_configs/buzzard_v1.6_2.yaml
+++ b/GCRCatalogs/catalog_configs/buzzard_v1.6_2.yaml
@@ -8,6 +8,8 @@ cosmology:
     H0: 70.0
     Om0: 0.286
     Ob0: 0.047
+    sigma8: 0.82
+    n_s: 0.96
 
 halo_mass_def: vir
 lightcone: true

--- a/GCRCatalogs/catalog_configs/buzzard_v1.6_21.yaml
+++ b/GCRCatalogs/catalog_configs/buzzard_v1.6_21.yaml
@@ -8,6 +8,8 @@ cosmology:
     H0: 70.0
     Om0: 0.286
     Ob0: 0.047
+    sigma8: 0.82
+    n_s: 0.96
 
 halo_mass_def: vir
 lightcone: true

--- a/GCRCatalogs/catalog_configs/buzzard_v1.6_3.yaml
+++ b/GCRCatalogs/catalog_configs/buzzard_v1.6_3.yaml
@@ -8,6 +8,8 @@ cosmology:
     H0: 70.0
     Om0: 0.286
     Ob0: 0.047
+    sigma8: 0.82
+    n_s: 0.96
 
 halo_mass_def: vir
 lightcone: true

--- a/GCRCatalogs/catalog_configs/buzzard_v1.6_5.yaml
+++ b/GCRCatalogs/catalog_configs/buzzard_v1.6_5.yaml
@@ -8,6 +8,8 @@ cosmology:
     H0: 70.0
     Om0: 0.286
     Ob0: 0.047
+    sigma8: 0.82
+    n_s: 0.96
 
 halo_mass_def: vir
 lightcone: true

--- a/GCRCatalogs/catalog_configs/buzzard_v1.6_test.yaml
+++ b/GCRCatalogs/catalog_configs/buzzard_v1.6_test.yaml
@@ -9,6 +9,8 @@ cosmology:
     H0: 70.0
     Om0: 0.286
     Ob0: 0.047
+    sigma8: 0.82
+    n_s: 0.96
 
 healpix_pixels: [42]
 halo_mass_def: vir

--- a/GCRCatalogs/catalog_configs/proto-dc2_v2.0_redmapper.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v2.0_redmapper.yaml
@@ -9,12 +9,14 @@ cosmology:
     H0: 71.0
     Om0: 0.265
     Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
 
 lightcone: true
 sky_area : 25.0
 
 creators: [ 'Andrew Benson', 'Andrew Hearin',  'Katrin Heitmann', 'Danila Korytov', 'Eve Kovacs', 'Eli Rykoff']
 description: |
-    cluster catalog and member catalog from the redMaPPer cluster finder run on proto-dc2. Red 
+    cluster catalog and member catalog from the redMaPPer cluster finder run on proto-dc2. Red
     sequence was fit in the standard way, but centers are on halo centers, i.e. a real halo finding
     run was not done.

--- a/GCRCatalogs/catalog_configs/proto-dc2_v3.0_redmapper.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v3.0_redmapper.yaml
@@ -9,12 +9,14 @@ cosmology:
     H0: 71.0
     Om0: 0.265
     Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
 
 lightcone: true
 sky_area : 25.0
 
 creators: [ 'Andrew Benson', 'Andrew Hearin',  'Katrin Heitmann', 'Danila Korytov', 'Eve Kovacs', 'Eli Rykoff']
 description: |
-    cluster catalog and member catalog from the redMaPPer cluster finder run on proto-dc2. Red 
+    cluster catalog and member catalog from the redMaPPer cluster finder run on proto-dc2. Red
     sequence was fit in the standard way, but centers are on halo centers, i.e. a real halo finding
     run was not done.

--- a/GCRCatalogs/catalog_configs/proto-dc2_v4.3_redmapper.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v4.3_redmapper.yaml
@@ -9,12 +9,14 @@ cosmology:
     H0: 71.0
     Om0: 0.265
     Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
 
 lightcone: true
 sky_area : 25.0
 
 creators: [ 'Andrew Benson', 'Andrew Hearin',  'Katrin Heitmann', 'Danila Korytov', 'Eve Kovacs', 'Eli Rykoff']
 description: |
-    cluster catalog and member catalog from the redMaPPer cluster finder run on proto-dc2. Red 
+    cluster catalog and member catalog from the redMaPPer cluster finder run on proto-dc2. Red
     sequence was fit in the standard way, but centers are on halo centers, i.e. a real halo finding
     run was not done.

--- a/GCRCatalogs/redmapper.py
+++ b/GCRCatalogs/redmapper.py
@@ -39,7 +39,15 @@ class RedMapperCatalog(BaseGenericCatalog):
         assert(os.path.isdir(catalog_root_dir)), 'Catalog directory {} does not exist'.format(catalog_root_dir)
 
         self._catalog_path_template = {k: os.path.join(catalog_root_dir, v) for k, v in catalog_path_template.items()}
-        self.cosmology = FlatLambdaCDM(**kwargs.get('cosmology'))
+
+        cosmology = kwargs.get('cosmology', {})
+        cosmo_astropy_allowed = FlatLambdaCDM.__init__.__code__.co_varnames[1:]
+        cosmo_astropy = {k: v for k, v in cosmology.items() if k in cosmo_astropy_allowed}
+        self.cosmology = FlatLambdaCDM(**cosmo_astropy)
+        for k, v in cosmology.items():
+            if k not in cosmo_astropy_allowed:
+                setattr(self.cosmology, k, v)
+
         self.lightcone = kwargs.get('lightcone')
         self.sky_area = kwargs.get('sky_area')
 


### PR DESCRIPTION
This PR fixes #44 by adding `sigma8` and `n_s` to the astropy cosmology object that can be accessed via
```python
gc = GCRCatalogs.load_catalog('buzzard_test')
sigma8 = gc.cosmology.sigma8
n_s = gc.cosmology.n_s
```
Note that these two attributes have no effect in `astropy.cosmology`. But before we switch to the TJP cosmology class, we will use this to store `sigma8` and `n_s`.

cc @chihway @EiffL @cosmicshear @patricialarsen as they have requested this feature. 