### PR TITLE
Update to v0.8.0 beta

### DIFF
--- a/GCRCatalogs/version.py
+++ b/GCRCatalogs/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.8.0-alpha'
+__version__ = '0.8.0-beta'


### PR DESCRIPTION
With the newly added truth catalog (and it's reader) and also the updates in GCR (including the more user-friendly native filters), I'd like to make a v0.8.0-beta release and upgrade this package in the DESC shared environment, so that tutorial writers and beta testers can access the new features.

Any objections? @EiffL, @danielsf, @wmwv?

