### PR TITLE
Remove `p` from truth and reference catalog names

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_reference_run1.1.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_reference_run1.1.yaml
@@ -1,3 +1,3 @@
 subclass_name: reference_catalog.ReferenceCatalogReader
 filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/reference_catalogs/dc2_reference_catalog_dc2v2.1.2.txt
-description: DC2 Reference Catalog Run 1.1p
+description: DC2 Reference Catalog Run 1.1 (corresponding to proto-dc2_v2.1.2)

--- a/GCRCatalogs/catalog_configs/dc2_reference_run1.2.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_reference_run1.2.yaml
@@ -1,3 +1,3 @@
 subclass_name: reference_catalog.ReferenceCatalogReader
 filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/reference_catalogs/dc2_reference_catalog_dc2v3_fov4.txt
-description: DC2 Reference Catalog Run 1.2p
+description: DC2 Reference Catalog Run 1.2 (corresponding to proto-dc2_v3.0)

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.1.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.1.yaml
@@ -5,7 +5,7 @@ filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/reference_catalogs/p
 md5: d035527eae197117cd1f7f3ddafd6df0
 
 description: |
-    Truth catalog for proto-dc2 run 1.1p (corresponding to proto-dc2_v2.1.2).
+    Truth catalog for proto-dc2 run 1.1 (corresponding to proto-dc2_v2.1.2).
     This is a truth catalog for static sources only.  There are no supernovae.
     Reported AGN magnitudes are the baseline magnitudes on top of which the
     variability model is layered.  This truth information was generated with

--- a/README.md
+++ b/README.md
@@ -52,12 +52,16 @@ at [this Confluence page](https://confluence.slac.stanford.edu/x/oJgHDg)
    - `dc2_coadd_run1.1p`: coadd catalog for Run 1.1p
    - `dc2_coadd_run1.1p_tract4850`: same as `dc2_coadd_run1.1p` but has only one tract (4850) for testing purpose / faster access
 
-4. DC2 "Reference Catalogs": \
+4. DC2 "Truth Catalogs": \
    *by LSST DESC, compiled by Scott Daniel*
-   - `dc2_reference_run1.1p`: reference catalog for Run 1.1p
-   - `dc2_reference_run1.2p`: reference catalog for Run 1.2p
+   - `dc2_truth_run1.1`: truth catalog for Run 1.1 (corresponds to `proto-dc2_v2.1.2`)
 
-5. DC2 "Instance Catalogs": \
+5. DC2 "Reference Catalogs": \
+   *by LSST DESC, compiled by Scott Daniel*
+   - `dc2_reference_run1.1`: reference catalog for Run 1.1 (corresponds to `proto-dc2_v2.1.2`)
+   - `dc2_reference_run1.2`: reference catalog for Run 1.2 (corresponds to `proto-dc2_v3.0`)
+
+6. DC2 "Instance Catalogs": \
    *by LSST DESC, compiled by Scott Daniel*
    - `dc2_instance_example1`: an example instance catalog
    - `dc2_instance_example2`: another example instance catalog


### PR DESCRIPTION
Based on the discussion in https://github.com/LSSTDESC/gcr-catalogs/pull/153#issuecomment-405751723, we are removing the `p` from truth and reference catalog names. 

This PR also updates the front-page README to reflect this. 

I don't think this would break too many things. (I think only @slosar's group is using reference catalog at this point.)

(and sorry for messing up the branch name...)