### PR TITLE
cache constant arrays for object catalog reader

### DIFF
--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -121,6 +121,7 @@ class TableWrapper(object):
     def _generate_constant_array(self, key, value):
         if key not in self._constant_arrays:
             self._constant_arrays[key] = np.repeat(value, len(self))
+            self._constant_arrays[key].setflags(write=False)
         return self._constant_arrays[key]
 
     def clear_cache(self):

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -115,7 +115,7 @@ class TableWrapper(object):
 
     get = __getitem__
 
-    def _get_constant_array(self, key):
+    def _get_constant_array(self, key): # pylint: disable=W0613
         return self._generate_constant_array('NaN', np.nan)
 
     def _generate_constant_array(self, key, value):


### PR DESCRIPTION
This PR enables caching of constant arrays for the object catalog reader. When a user tries to access a column that is supposed to be there (i.e., in the schema) but not actually in that patch, a constant array of NaN is returned. Similarly when the user tries to obtain a column of tract number or patch string. 

Since these constant arrays are, as the name suggests, constant, there's no need to recreate them. This PR make it possible to cache those arrays. 

This change does slightly improve the data access performance.  

Thanks for @wmwv's suggestion in #168. This PR fixes #168.