### PR TITLE
bug fix in the UMShearCatalog reader

### DIFF
--- a/GCRCatalogs/cosmodc2.py
+++ b/GCRCatalogs/cosmodc2.py
@@ -466,8 +466,3 @@ class UMShearCatalog(UMGalaxyCatalog):
             'shear_2_phosim':   (np.negative, 'shear_2'),
         }
         return quantity_modifiers
-
-    def _subclass_init(self, catalog_root_dir, catalog_path_template, cosmology, healpix_pixels=None, zlo=None, zhi=None, check_file_metadata=False, **kwargs):
-        super(UMShearCatalog, self)._subclass_init(catalog_root_dir, catalog_path_template, cosmology, healpix_pixels=None, zlo=None, zhi=None, check_file_metadata=False, **kwargs)
-        self.composite_compatible = kwargs.get('composite_compatible', [])
-        self.composite_matched_format = kwargs.get('composite_matched_format', [])


### PR DESCRIPTION
With the new composite reader, `UMShearCatalog` can just use the same `_subclass_init` as in `UMGalaxyCatalog`.

This should fix a bug that @evevkovacs encountered. 