### PR TITLE
add base_filters option to truth catalog reader

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_run1.1_extragalactic_truth_match.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_run1.1_extragalactic_truth_match.yaml
@@ -1,0 +1,13 @@
+subclass_name: composite.CompositeReader
+catalogs:
+  - catalog_name: protodc2
+    matching_method: galaxy_id
+    subclass_name: alphaq.AlphaQGalaxyCatalog
+    filename: /global/projecta/projectdirs/lsst/groups/CS/descqa/catalog/ANL_AlphaQ_v2.1.2.hdf5
+  - catalog_name: truth
+    matching_method: object_id
+    subclass_name: dc2_truth.DC2TruthCatalogReader
+    filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/reference_catalogs/proto_dc2_truth_star_gal_180720.db
+    base_filters:
+        - sprinkled == 0
+        - star == 0

--- a/GCRCatalogs/catalog_configs/dc2_run1.1_extragalactic_truth_match.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_run1.1_extragalactic_truth_match.yaml
@@ -11,3 +11,4 @@ catalogs:
     base_filters:
         - sprinkled == 0
         - star == 0
+        - agn == 0

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.1_galaxies.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.1_galaxies.yaml
@@ -1,0 +1,17 @@
+subclass_name: dc2_truth.DC2TruthCatalogReader
+
+filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/reference_catalogs/proto_dc2_truth_star_gal_180720.db
+
+md5: a8f0e1d656d44eb3c718be1a98e2a0ae
+
+base_filters:
+    - sprinkled == 0
+    - star == 0
+
+description: |
+    Truth catalog for proto-dc2 run 1.1 (corresponding to proto-dc2_v2.1.2).
+    This is a truth catalog for galaxies and AGNs only.
+    There are no stars and supernovae.
+    Reported AGN magnitudes are the baseline magnitudes on top of which the
+    variability model is layered.  This truth information was generated with
+    version 2.1.2 of the proto-DC2 extragalactic catalog.

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.1_galaxies.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.1_galaxies.yaml
@@ -7,6 +7,7 @@ md5: a8f0e1d656d44eb3c718be1a98e2a0ae
 base_filters:
     - sprinkled == 0
     - star == 0
+    - agn == 0
 
 description: |
     Truth catalog for proto-dc2 run 1.1 (corresponding to proto-dc2_v2.1.2).

--- a/GCRCatalogs/utils.py
+++ b/GCRCatalogs/utils.py
@@ -3,6 +3,8 @@ utility module
 """
 import hashlib
 
+__all__ = ['md5', 'is_string_like']
+
 def md5(fname, chunk_size=65536):
     """
     generate MD5 sum for *fname*
@@ -12,3 +14,14 @@ def md5(fname, chunk_size=65536):
         for chunk in iter(lambda: f.read(chunk_size), b''):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
+
+
+def is_string_like(obj):
+    """
+    test if `obj` is string like
+    """
+    try:
+        obj + ''
+    except (TypeError, ValueError):
+        return False
+    return True


### PR DESCRIPTION
This PR adds the `base_filters` option to the truth catalog reader. When `base_filters` is specified, it will be always included in the `WHERE` clause. This is useful to create a "phony" truth catalog that contains only galaxies (as demonstrated in `dc2_truth_run1.1_galaxies.yaml`). 

This PR also adds a config to create a composite catalog that joins the galaxy-only truth catalog and the extragalactic catalog (`dc2_run1.1_extragalactic_truth_match.yaml`). We can then write a DESCQA test for  this composite catalog to fullfill https://github.com/LSSTDESC/descqa/issues/129. (Thanks @evevkovacs for suggestion.)