### PR TITLE
Make rescale function call future compatible 

### DIFF
--- a/GCRCatalogs/focal_plane.py
+++ b/GCRCatalogs/focal_plane.py
@@ -35,7 +35,7 @@ class Sensor(object):
     def get_data(self):
         data = FitsFile(self.path).data
         if self.rebinning != 1:
-            data = rescale(data, 1 / self.rebinning, preserve_range=True)
+            data = rescale(data, 1 / self.rebinning, mode='constant', preserve_range=True, multichannel=False, anti_aliasing=True)
         return data
 
 class Raft(object):


### PR DESCRIPTION
This PR is to make the `rescale` function called in `focal_plane.py` future compatible with scikit-image 0.15+