### PR TITLE
add support to legacy instance catalogs

### DIFF
--- a/GCRCatalogs/instance_catalog.py
+++ b/GCRCatalogs/instance_catalog.py
@@ -217,6 +217,13 @@ class InstanceCatalog(BaseGenericCatalog):
                 raise ValueError('cannot determine whether this is a legacy instance catalog!')
             for t in self._legacy_gal_types:
                 self._object_files[t] = self._object_files['gal']
+            del self._object_files['gal']
+
+        try:
+            self.visit = int(self.header.get('obshistid'))
+        except (TypeError, ValueError):
+            warnings.warn('Cannot parse visit id {}'.format(self.header.get('obshistid')))
+            self.visit = None
 
         shape_quantities = ('gal/a_bulge',
                             'gal/b_bulge',

--- a/GCRCatalogs/instance_catalog.py
+++ b/GCRCatalogs/instance_catalog.py
@@ -183,7 +183,6 @@ class InstanceCatalog(BaseGenericCatalog):
 
     def _subclass_init(self, **kwargs):
         self.header_file = kwargs['header_file']
-        self.legacy_gal_catalog = bool(kwargs.get('legacy_gal_catalog'))
 
         if not os.path.isfile(self.header_file):
             raise ValueError('Header file {} does not exist'.format(self.header_file))
@@ -194,24 +193,29 @@ class InstanceCatalog(BaseGenericCatalog):
         self.cosmology = FlatLambdaCDM(H0=71, Om0=0.265, Ob0=0.0448)
         self.lightcone = True
 
+        self.legacy_gal_catalog = False
         self._data = dict()
         self._object_files = dict()
         for filename in self.header['includeobj']:
             obj_type = filename.partition('_cat_')[0]
             full_path = os.path.join(self.base_dir, filename)
 
-            if self.legacy_gal_catalog and obj_type == 'gal':
+            if not os.path.isfile(full_path):
+                warnings.warn('Cannot find file {}! Skipped!'.format(full_path))
+
+            elif obj_type == 'gal':
+                self.legacy_gal_catalog = True
                 for t in self._legacy_gal_types:
                     self._object_files[t] = full_path
 
             elif obj_type not in self._col_names:
                 warnings.warn('Unknown object type {}! Skipped!'.format(obj_type))
 
-            elif not os.path.isfile(full_path):
-                warnings.warn('Cannot find file {}! Skipped!'.format(full_path))
-
             else:
                 self._object_files[obj_type] = full_path
+
+        if self.legacy_gal_catalog and any(t in self._object_files for t in self._legacy_gal_types):
+            raise ValueError('cannot determine whether this is a legacy instance catalog!')
 
         shape_quantities = ('gal/a_bulge',
                             'gal/b_bulge',

--- a/GCRCatalogs/instance_catalog.py
+++ b/GCRCatalogs/instance_catalog.py
@@ -198,24 +198,25 @@ class InstanceCatalog(BaseGenericCatalog):
         self._object_files = dict()
         for filename in self.header['includeobj']:
             obj_type = filename.partition('_cat_')[0]
-            full_path = os.path.join(self.base_dir, filename)
 
-            if not os.path.isfile(full_path):
-                warnings.warn('Cannot find file {}! Skipped!'.format(full_path))
-
-            elif obj_type == 'gal':
+            if obj_type == 'gal':
                 self.legacy_gal_catalog = True
-                for t in self._legacy_gal_types:
-                    self._object_files[t] = full_path
-
             elif obj_type not in self._col_names:
                 warnings.warn('Unknown object type {}! Skipped!'.format(obj_type))
+                continue
 
-            else:
-                self._object_files[obj_type] = full_path
+            full_path = os.path.join(self.base_dir, filename)
+            if not os.path.isfile(full_path):
+                warnings.warn('Cannot find file {}! Skipped!'.format(full_path))
+                continue
 
-        if self.legacy_gal_catalog and any(t in self._object_files for t in self._legacy_gal_types):
-            raise ValueError('cannot determine whether this is a legacy instance catalog!')
+            self._object_files[obj_type] = full_path
+
+        if self.legacy_gal_catalog:
+            if any(t in self._object_files for t in self._legacy_gal_types):
+                raise ValueError('cannot determine whether this is a legacy instance catalog!')
+            for t in self._legacy_gal_types:
+                self._object_files[t] = self._object_files['gal']
 
         shape_quantities = ('gal/a_bulge',
                             'gal/b_bulge',

--- a/GCRCatalogs/instance_catalog.py
+++ b/GCRCatalogs/instance_catalog.py
@@ -271,7 +271,6 @@ class InstanceCatalog(BaseGenericCatalog):
             delim_whitespace=True,
             names=[c[0] for c in self._col_names[obj_type]],
             dtype=dict(self._col_names[obj_type]),
-            na_filter=False,
             **kwargs
         )
 
@@ -281,7 +280,7 @@ class InstanceCatalog(BaseGenericCatalog):
             this_open = gzip.open if path.endswith('.gz') else open
             with this_open(path, 'rb') as f:
                 for index, line in enumerate(f):
-                    if b'agnSED/' in line:
+                    if b' agnSED/' in line:
                         self._data['_legacy_gal_line_index'] = index
                         break
 


### PR DESCRIPTION
To allow the validation test proposed in  https://github.com/LSSTDESC/descqa/issues/152 work with legacy instance catalogs (AGNs and galaxies are printed in the same file), we need to update the instance catalog reader so that it works with both cases. This PR adds the said support. 