### PR TITLE
Reader update and config files for cosmoDC2_v1.0

### DIFF
--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0.yaml
@@ -1,0 +1,22 @@
+subclass_name: cosmodc2.CosmoDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/cosmoDC2_v1.0.0_full_highres
+catalog_filename_template: z_{}_{}.step_all.healpix_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+lightcone: true
+
+version: "1.0.0"
+
+check_md5: false
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+
+description: |
+    This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_10194_10452.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_10194_10452.yaml
@@ -1,0 +1,25 @@
+subclass_name: cosmodc2.CosmoDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/cosmoDC2_v1.0.0_full_highres
+catalog_filename_template: z_{}_{}.step_all.healpix_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+lightcone: true
+
+version: "1.0.0"
+
+healpix_pixels: [10194, 10195, 10196, 10197, 10198, 10199, 10200, 10201, 10202, 10321, 10322, 10323, 10324, 10325, 10326, 10327, 10328, 10329, 10445, 10446, 10447, 10448, 10449, 10450,
+                 10451, 10452]
+
+check_md5: false
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+
+description: |
+    This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_8786_9049.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_8786_9049.yaml
@@ -1,0 +1,25 @@
+subclass_name: cosmodc2.CosmoDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/cosmoDC2_v1.0.0_full_highres
+catalog_filename_template: z_{}_{}.step_all.healpix_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+lightcone: true
+
+version: "1.0.0"
+
+healpix_pixels: [8786, 8787, 8788, 8789, 8790, 8791, 8792, 8793, 8794, 8913, 8914, 8915, 8916, 8917, 8918, 8919, 8920, 8921, 9042, 9043, 9044, 9045, 9046, 9047, 9048, 9049,
+                ]
+
+check_md5: false
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+
+description: |
+    This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9050_9430.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9050_9430.yaml
@@ -1,0 +1,25 @@
+subclass_name: cosmodc2.CosmoDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/cosmoDC2_v1.0.0_full_highres
+catalog_filename_template: z_{}_{}.step_all.healpix_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+lightcone: true
+
+version: "1.0.0"
+
+healpix_pixels: [9050, 9169, 9170, 9171, 9172, 9173, 9174, 9175, 9176, 9177, 9178, 9298, 9299, 9300, 9301, 9302, 9303, 9304, 9305, 9306, 9425, 9426, 9427, 9428, 9429, 9430,
+                ]
+
+check_md5: false
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+
+description: |
+    This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9431_9812.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9431_9812.yaml
@@ -1,0 +1,25 @@
+subclass_name: cosmodc2.CosmoDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/cosmoDC2_v1.0.0_full_highres
+catalog_filename_template: z_{}_{}.step_all.healpix_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+lightcone: true
+
+version: "1.0.0"
+
+healpix_pixels: [9431, 9432, 9433, 9434, 9554, 9555, 9556, 9557, 9558, 9559, 9560, 9561, 9562, 9681, 9682, 9683, 9684, 9685, 9686, 9687, 9688, 9689, 9690, 9810, 9811, 9812,
+                ]
+
+check_md5: false
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+
+description: |
+    This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9556.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9556.yaml
@@ -1,0 +1,24 @@
+subclass_name: cosmodc2.CosmoDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/cosmoDC2_v1.0.0_full_highres
+catalog_filename_template: z_{}_{}.step_all.healpix_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+lightcone: true
+
+version: "1.0.0"
+
+healpix_pixels: [9556]
+
+check_md5: false
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+
+description: |
+    This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9813_10193.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9813_10193.yaml
@@ -1,0 +1,25 @@
+subclass_name: cosmodc2.CosmoDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/cosmoDC2_v1.0.0_full_highres
+catalog_filename_template: z_{}_{}.step_all.healpix_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+lightcone: true
+
+version: "1.0.0"
+
+healpix_pixels: [9813, 9814, 9815, 9816, 9817, 9818, 9937, 9938, 9939, 9940, 9941, 9942, 9943, 9944, 9945, 9946, 10066, 10067, 10068, 10069, 10070, 10071, 10072, 10073, 10074, 10193,
+                ]
+
+check_md5: false
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+
+description: |
+    This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_image.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_image.yaml
@@ -1,0 +1,29 @@
+subclass_name: cosmodc2.CosmoDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/cosmoDC2_v1.0.0_full_highres
+catalog_filename_template: z_{}_{}.step_all.healpix_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+lightcone: true
+
+version: "1.0.0"
+
+healpix_pixels: [8786, 8787, 8788, 8789, 8790, 8791, 8792, 8793, 8794, 8913, 8914, 8915, 8916, 8917, 8918, 8919, 8920, 8921, 9042, 9043, 9044, 9045, 9046, 9047, 9048, 9049,
+                 9050, 9169, 9170, 9171, 9172, 9173, 9174, 9175, 9176, 9177, 9178, 9298, 9299, 9300, 9301, 9302, 9303, 9304, 9305, 9306, 9425, 9426, 9427, 9428, 9429, 9430,
+                 9431, 9432, 9433, 9434, 9554, 9555, 9556, 9557, 9558, 9559, 9560, 9561, 9562, 9681, 9682, 9683, 9684, 9685, 9686, 9687, 9688, 9689, 9690, 9810, 9811, 9812,
+                 9813, 9814, 9815, 9816, 9817, 9818, 9937, 9938, 9939, 9940, 9941, 9942, 9943, 9944, 9945, 9946, 10066, 10067, 10068, 10069, 10070, 10071, 10072, 10073, 10074, 10193,
+                 10194, 10195, 10196, 10197, 10198, 10199, 10200, 10201, 10202, 10321, 10322, 10323, 10324, 10325, 10326, 10327, 10328, 10329, 10445, 10446, 10447, 10448, 10449, 10450,
+                 10451, 10452]
+
+check_md5: false
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+
+description: |
+    This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/cosmodc2.py
+++ b/GCRCatalogs/cosmodc2.py
@@ -40,21 +40,35 @@ def _calc_mag(conv, shear1, shear2):
     return mag
 
 
-def _calc_Rv(lum_v, lum_v_dust, lum_b, lum_b_dust):
+def _calc_Rv_old(lum_v, lum_v_dust, lum_b, lum_b_dust):
     with np.errstate(divide='ignore', invalid='ignore'):
+        print('Using Rv original function')
         v = lum_v_dust/lum_v
         b = lum_b_dust/lum_b
         bv = b/v
         Rv = np.log10(v) / np.log10(bv)
-        Rv[(v == 1) & (b == 1)] = 1.0
         Rv[v == b] = np.nan
+        Rv[(v == 1) & (b == 1)] = 1.0
+        return Rv
+
+
+def _calc_Rv(lum_v, lum_v_dust, lum_b, lum_b_dust): #Rv definition with best behavior
+    with np.errstate(divide='ignore', invalid='ignore'):
+        Av = -2.5*np.log10(lum_v_dust) + 2.5*np.log10(lum_v)
+        Ab = -2.5*np.log10(lum_b_dust) + 2.5*np.log10(lum_b)
+        Ebv = -2.5*np.log10(lum_b_dust) + 2.5*np.log10(lum_b) - 2.5*np.log10(lum_v_dust) + 2.5*np.log10(lum_v)
+        Rv = Av / Ebv
+        Rv[(Av == 0) & (Ab == 0)] = 1.0         
+        #remove remaining nans and infs for image sims
+        mask = np.isfinite(Rv)
+        Rv[~mask] = np.random.uniform(1.0, 5.0, np.sum(~mask))
         return Rv
 
 
 def _calc_Av(lum_v, lum_v_dust):
     with np.errstate(divide='ignore', invalid='ignore'):
         Av = -2.5*(np.log10(lum_v_dust/lum_v))
-        Av[lum_v_dust == 0] = np.nan
+        #Av[lum_v_dust == 0] = np.nan
         return Av
 
 


### PR DESCRIPTION
Reader updates and configuration files for cosmoDC2_v1.0. Config files specify subsets of healpixels used for validation of the image-simulation area. Examples of reader and tests are [here](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-09-10_12&catalog=cosmoDC2_v1.0_10194_10452) Similar tests are in the run list for the other sub-volumes. 