### PR TITLE
turn off checks for some older catalogs to suppress warning

### DIFF
--- a/GCRCatalogs/catalog_configs/baseDC2_v0.4.5.yaml
+++ b/GCRCatalogs/catalog_configs/baseDC2_v0.4.5.yaml
@@ -15,6 +15,7 @@ lightcone: true
 version: "0.4.5"
 
 check_md5: false
+check_size: false
 
 creators: [ 'Danila Korytov', 'Andrew Hearin',  'Eve Kovacs', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
 

--- a/GCRCatalogs/catalog_configs/baseDC2_v0.4.5_shear.yaml
+++ b/GCRCatalogs/catalog_configs/baseDC2_v0.4.5_shear.yaml
@@ -16,4 +16,5 @@ catalogs:
     check_md5: false
     check_version: false
     check_cosmology: false
+    check_size: false
     creators: ['Patricia Larsen']

--- a/GCRCatalogs/catalog_configs/baseDC2_v0.4.5_test.yaml
+++ b/GCRCatalogs/catalog_configs/baseDC2_v0.4.5_test.yaml
@@ -17,6 +17,7 @@ version: "0.4.5"
 healpix_pixels: [564]
 
 check_md5: false
+check_size: false
 
 creators: [ 'Danila Korytov', 'Andrew Hearin',  'Eve Kovacs', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
 

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v0.1.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v0.1.yaml
@@ -15,6 +15,8 @@ lightcone: true
 version: "0.1.0"
 
 check_md5: false
+check_size: false
+check_cosmology: false
 
 creators: [ 'Andrew Benson', 'Andrew Hearin', 'Katrin Heitmann', 'Danila Korytov', 'Eve Kovacs', 'Patricia Larsen']
 

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v0.1_test.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v0.1_test.yaml
@@ -17,6 +17,8 @@ version: "0.1.0"
 healpix_pixels: [564]
 
 check_md5: false
+check_size: false
+check_cosmology: false
 
 creators: [ 'Andrew Benson', 'Andrew Hearin', 'Katrin Heitmann', 'Danila Korytov', 'Eve Kovacs', 'Patricia Larsen']
 

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v0.4_test.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v0.4_test.yaml
@@ -17,6 +17,8 @@ version: "0.4.2"
 healpix_pixels: [564]
 
 check_md5: false
+check_size: false
+check_cosmology: false
 
 creators: [ 'Andrew Benson', 'Andrew Hearin', 'Katrin Heitmann', 'Danila Korytov', 'Eve Kovacs', 'Patricia Larsen']
 

--- a/GCRCatalogs/cosmodc2.py
+++ b/GCRCatalogs/cosmodc2.py
@@ -123,15 +123,17 @@ class CosmoDC2ParentClass(BaseGenericCatalog):
         if StrictVersion(__version__) < self.version:
             raise ValueError('Reader version {} is less than config version {} for'.format(__version__, self.version))
 
-        try:
-            with open(CHECK_FILE_PATH, 'r') as f:
-                self.file_check_info = yaml.load(f)
-        except (IOError, OSError):
-            self.file_check_info = dict()
-        else:
-            self.file_check_info = self.file_check_info.get(self.version, dict())
-        if not self.file_check_info:
-            warnings.warn('Cannot find valid infomation for file checks! Version {} not available in {}'.format(self.version, CHECK_FILE_PATH))
+        self.file_check_info = dict()
+        if kwargs.get('check_md5', True) or kwargs.get('check_size', True):
+            try:
+                with open(CHECK_FILE_PATH, 'r') as f:
+                    self.file_check_info = yaml.load(f)
+            except (IOError, OSError):
+                pass
+            else:
+                self.file_check_info = self.file_check_info.get(self.version, dict())
+            if not self.file_check_info:
+                warnings.warn('Cannot find valid infomation for file checks! Version {} not available in {}'.format(self.version, CHECK_FILE_PATH))
 
         self.lightcone = kwargs.get('lightcone', True)
         self.sky_area, self._native_quantities, self._quantity_info = self._process_metadata(**kwargs)


### PR DESCRIPTION
This PR turns off some checks (size/cosmology) for some older catalogs to suppress warning. 