### PR TITLE
 Update to list of creators for cosmoDC2_v1.0

### DIFF
--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0.yaml
@@ -16,7 +16,7 @@ version: "1.0.0"
 
 check_md5: false
 
-creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
 
 description: |
     This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_10194_10452.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_10194_10452.yaml
@@ -19,7 +19,7 @@ healpix_pixels: [10194, 10195, 10196, 10197, 10198, 10199, 10200, 10201, 10202, 
 
 check_md5: false
 
-creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
 
 description: |
     This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_8786_9049.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_8786_9049.yaml
@@ -19,7 +19,7 @@ healpix_pixels: [8786, 8787, 8788, 8789, 8790, 8791, 8792, 8793, 8794, 8913, 891
 
 check_md5: false
 
-creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
 
 description: |
     This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9050_9430.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9050_9430.yaml
@@ -19,7 +19,7 @@ healpix_pixels: [9050, 9169, 9170, 9171, 9172, 9173, 9174, 9175, 9176, 9177, 917
 
 check_md5: false
 
-creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
 
 description: |
     This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9431_9812.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9431_9812.yaml
@@ -19,7 +19,7 @@ healpix_pixels: [9431, 9432, 9433, 9434, 9554, 9555, 9556, 9557, 9558, 9559, 956
 
 check_md5: false
 
-creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
 
 description: |
     This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9556.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9556.yaml
@@ -18,7 +18,7 @@ healpix_pixels: [9556]
 
 check_md5: false
 
-creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
 
 description: |
-    This is the extra-galactic catalog for the LSST-DESC data challenge DC2.
+    This is small sub-volume (3.4 sq. deg.) of the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9813_10193.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_9813_10193.yaml
@@ -19,7 +19,7 @@ healpix_pixels: [9813, 9814, 9815, 9816, 9817, 9818, 9937, 9938, 9939, 9940, 994
 
 check_md5: false
 
-creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
 
 description: |
     This is the extra-galactic catalog for the LSST-DESC data challenge DC2.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_image.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_image.yaml
@@ -23,7 +23,7 @@ healpix_pixels: [8786, 8787, 8788, 8789, 8790, 8791, 8792, 8793, 8794, 8913, 891
 
 check_md5: false
 
-creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Andrew Benson', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
 
 description: |
-    This is the extra-galactic catalog for the LSST-DESC data challenge DC2.
+    This is the extra-galactic catalog used in image simulations for the LSST-DESC data challenge DC2.


### PR DESCRIPTION
A minor change to the cosmoDC2 configuration files to include all of the main creators, prior to official release. Sample run:  https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-09-19_2
