### PR TITLE
rename dc2_truth_1.1 to dc2_truth_1.1_static

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_run1.2_extragalactic_truth_match.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_run1.2_extragalactic_truth_match.yaml
@@ -1,0 +1,16 @@
+subclass_name: composite.CompositeReader
+description: matched catalog between extragalactic and truth for Run 1.2 (protoDC2 3.0.0)
+catalogs:
+  - catalog_name: extragalactic
+    matching_method: galaxy_id
+    subclass_name: alphaq.AlphaQGalaxyCatalog
+    filename: /global/projecta/projectdirs/lsst/groups/CS/descqa/catalog/ANL_AlphaQ_v3.0.hdf5
+    version: 3.0.0
+  - catalog_name: truth
+    matching_method: object_id
+    subclass_name: dc2_truth.DC2TruthCatalogReader
+    filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/Run1.2/run_1.2_trial_static.db
+    base_filters:
+        - sprinkled == 0
+        - star == 0
+        - agn == 0

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.1.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.1.yaml
@@ -1,12 +1,1 @@
-subclass_name: dc2_truth.DC2TruthCatalogReader
-
-filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/reference_catalogs/proto_dc2_truth_star_gal_180720.db
-
-md5: a8f0e1d656d44eb3c718be1a98e2a0ae
-
-description: |
-    Truth catalog for proto-dc2 run 1.1 (corresponding to proto-dc2_v2.1.2).
-    This is a truth catalog for static sources only.  There are no supernovae.
-    Reported AGN magnitudes are the baseline magnitudes on top of which the
-    variability model is layered.  This truth information was generated with
-    version 2.1.2 of the proto-DC2 extragalactic catalog.
+alias: dc2_truth_run1.1_static

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.1_static.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.1_static.yaml
@@ -10,3 +10,5 @@ description: |
     Reported AGN magnitudes are the baseline magnitudes on top of which the
     variability model is layered.  This truth information was generated with
     version 2.1.2 of the proto-DC2 extragalactic catalog.
+
+included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.1_static.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.1_static.yaml
@@ -1,0 +1,12 @@
+subclass_name: dc2_truth.DC2TruthCatalogReader
+
+filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/reference_catalogs/proto_dc2_truth_star_gal_180720.db
+
+md5: a8f0e1d656d44eb3c718be1a98e2a0ae
+
+description: |
+    Truth catalog for proto-dc2 run 1.1 (corresponding to proto-dc2_v2.1.2).
+    This is a truth catalog for static sources only.  There are no supernovae.
+    Reported AGN magnitudes are the baseline magnitudes on top of which the
+    variability model is layered.  This truth information was generated with
+    version 2.1.2 of the proto-DC2 extragalactic catalog.


### PR DESCRIPTION
For truth catalog run 1.2, the catalog are named as
- `dc2_truth_1.2_static`
- `dc2_truth_run1.2_variable_summary`
- `dc2_truth_run1.2_variable_lightcurve`

This PR renames `dc2_truth_1.1` to `dc2_truth_1.1_static` to be consistent with the naming scheme of 1.2. Also, this PR makes `dc2_truth_1.1` an alias to `dc2_truth_1.1_static` for backward compatibility. 