### PR TITLE
update catalogs that are displayed by default in the catalog list

### DIFF
--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0.yaml
@@ -20,3 +20,5 @@ creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'P
 
 description: |
     This is the extra-galactic catalog for the LSST-DESC data challenge DC2.
+
+included_by_default: true

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_image.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_image.yaml
@@ -27,3 +27,5 @@ creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'P
 
 description: |
     This is the extra-galactic catalog used in image simulations for the LSST-DESC data challenge DC2.
+
+included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_eimages_run1.2i_visit-181898.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_eimages_run1.2i_visit-181898.yaml
@@ -4,4 +4,3 @@ dirpath_contain: 000008_batch
 visits: 181898
 default_rebinning: 16
 description: ImSim e-images for Run 1.2i (visit 181898)
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_eimages_run1.2p_visit-181898.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_eimages_run1.2p_visit-181898.yaml
@@ -3,4 +3,3 @@ root_dir: /global/projecta/projectdirs/lsst/global/DC2/DC2-R1-2p-WFD-r/000008
 visits: 181898
 default_rebinning: 16
 description: phoSim e-images for Run 1.2p (visit 181898)
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.2_static.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.2_static.yaml
@@ -4,3 +4,5 @@ filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/Run1.2/run_1.2_trial
 
 description: |
     Truth catalog for Run 1.2. Static objects.
+
+included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.2_variable_lightcurve.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.2_variable_lightcurve.yaml
@@ -8,3 +8,5 @@ table_obs_metadata: obs_metadata
 
 description: |
     Truth catalog for Run 1.2, light curve tables for variable objects.
+
+included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.2_variable_summary.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.2_variable_summary.yaml
@@ -6,3 +6,5 @@ is_static: False
 
 description: |
     Truth catalog for Run 1.2, summary table for variable objects.
+
+included_by_default: true

--- a/GCRCatalogs/catalog_configs/proto-dc2_v2.1.2_test.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v2.1.2_test.yaml
@@ -12,3 +12,5 @@ description: |
     ProtoDC2 is a down-scaled version of the catalog to be generated for LSST-DESC DC2.
     For a description of the catalog and the methods, please see https://goo.gl/fXDQwP
     No check of MD5 sum in this version.
+
+included_by_default: true

--- a/GCRCatalogs/catalog_configs/proto-dc2_v3.0_test.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v3.0_test.yaml
@@ -11,3 +11,5 @@ creators: [ 'Andrew Benson', 'Andrew Hearin',  'Katrin Heitmann', 'Danila Koryto
 description: |
     ProtoDC2 is a down-scaled version of the catalog to be generated for LSST-DESC DC2.
     For a description of the catalog and the methods, please see https://goo.gl/fXDQwP
+
+included_by_default: true

--- a/GCRCatalogs/catalog_configs/protoDC2_test.yaml
+++ b/GCRCatalogs/catalog_configs/protoDC2_test.yaml
@@ -1,1 +1,2 @@
 alias: proto-dc2_v5.0_test
+included_by_default: true


### PR DESCRIPTION
This PR updates the `included_by_default` flag in the catalog config to make a more reasonable list of catalogs that are displayed by default in the catalog list