### PR TITLE
Issues/219

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
@@ -1,6 +1,6 @@
 subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog
-filename_pattern: 'trim_object_tract_[0-9]+\.hdf5$'
+filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog
 creators: ['Michael Wood-Vasey']
 included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
@@ -1,0 +1,7 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog
+filename_pattern: 'trim_object_tract_[0-9]+\.hdf5$'
+description: DC2 Run 1.2i Object Catalog
+creators: ['Michael Wood-Vasey']
+included_by_default: true
+pixel_scale: 0.185

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
@@ -1,6 +1,6 @@
 subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog
-filename_pattern: 'object_tract_*\.hdf5$'
+filename_pattern: 'object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog
 creators: ['Michael Wood-Vasey']
 included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
@@ -1,0 +1,7 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog
+filename_pattern: 'object_tract_*\.hdf5$'
+description: DC2 Run 1.2i Object Catalog
+creators: ['Michael Wood-Vasey']
+included_by_default: true
+pixel_scale: 0.185

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract4850.yaml
@@ -1,0 +1,7 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog
+filename_pattern: 'object_tract_4850\.hdf5$'
+description: 'DC2 Run 1.2i Object Catalog Tract 4850'
+creators: ['Michael Wood-Vasey']
+included_by_default: true
+pixel_scale: 0.185


### PR DESCRIPTION
Add DC2 Object catalogs for Run 1.2i
`dc2_object_run1.2i` defaults to the trimmed HDF5 catalogs.
`dc2_object_run1.2i_tract4850` a smaller test case of just tract=4850.
`dc2_object_run1.2i_all_columns` gives access to the full columns.
