### PR TITLE
Specify the schema_path for dc2_object_run1.2i{,_all_columns}

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
@@ -1,5 +1,6 @@
 subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog
+schema_path: trim_schema.yaml
 filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog
 creators: ['Michael Wood-Vasey']

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
@@ -1,5 +1,6 @@
 subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog
+schema_path: schema.yaml
 filename_pattern: 'object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog
 creators: ['Michael Wood-Vasey']


### PR DESCRIPTION
The full schema for the full file is `schema.yaml`
The trimed schema for the trim file is `trim_schema.yaml`.

The `trim_object*` files in the `Run1.2i/object_catalog` directory have also been updated.  There was an error in their original generation.