### PR TITLE
minor bug fix for empty timestep +config files for baseDC2

### DIFF
--- a/GCRCatalogs/catalog_configs/baseDC2_v1.1_9431_9812.yaml
+++ b/GCRCatalogs/catalog_configs/baseDC2_v1.1_9431_9812.yaml
@@ -1,0 +1,26 @@
+subclass_name: cosmodc2.BaseDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/baseDC2_v1.1
+catalog_filename_template: baseDC2_z_{}_{}_cutout_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    n_s: 0.963
+    sigma8: 0.8
+
+lightcone: true
+
+version: "1.1.2"
+
+healpix_pixels: [9431, 9432, 9433, 9434, 9554, 9555, 9556, 9557, 9558, 9559, 9560, 9561, 9562, 9681, 9682, 9683, 9684, 9685, 9686, 9687, 9688, 9689, 9690, 9810, 9811, 9812,
+                ]
+
+check_md5: false
+check_size: false
+
+creators: [ 'Danila Korytov', 'Andrew Hearin',  'Eve Kovacs', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+
+description: |
+    This is the baseline catalog characterizing the galaxy-halo connection for LSST-DESC cosmoDC2.

--- a/GCRCatalogs/catalog_configs/baseDC2_v1.1_9556.yaml
+++ b/GCRCatalogs/catalog_configs/baseDC2_v1.1_9556.yaml
@@ -1,0 +1,25 @@
+subclass_name: cosmodc2.BaseDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/baseDC2_v1.1
+catalog_filename_template: baseDC2_z_{}_{}_cutout_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    n_s: 0.963
+    sigma8: 0.8
+
+lightcone: true
+
+version: "1.1.2"
+
+healpix_pixels: [9556]
+
+check_md5: false
+check_size: false
+
+creators: [ 'Danila Korytov', 'Andrew Hearin',  'Eve Kovacs', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+
+description: |
+    This is the baseline catalog characterizing the galaxy-halo connection for LSST-DESC cosmoDC2.

--- a/GCRCatalogs/catalog_configs/baseDC2_v1.1_image.yaml
+++ b/GCRCatalogs/catalog_configs/baseDC2_v1.1_image.yaml
@@ -1,0 +1,30 @@
+subclass_name: cosmodc2.BaseDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/baseDC2_v1.1
+catalog_filename_template: baseDC2_z_{}_{}_cutout_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    n_s: 0.963
+    sigma8: 0.8
+
+lightcone: true
+
+version: "1.1.2"
+
+healpix_pixels: [8786, 8787, 8788, 8789, 8790, 8791, 8792, 8793, 8794, 8913, 8914, 8915, 8916, 8917, 8918, 8919, 8920, 8921, 9042, 9043, 9044, 9045, 9046, 9047, 9048, 9049,
+                 9050, 9169, 9170, 9171, 9172, 9173, 9174, 9175, 9176, 9177, 9178, 9298, 9299, 9300, 9301, 9302, 9303, 9304, 9305, 9306, 9425, 9426, 9427, 9428, 9429, 9430,
+                 9431, 9432, 9433, 9434, 9554, 9555, 9556, 9557, 9558, 9559, 9560, 9561, 9562, 9681, 9682, 9683, 9684, 9685, 9686, 9687, 9688, 9689, 9690, 9810, 9811, 9812,
+                 9813, 9814, 9815, 9816, 9817, 9818, 9937, 9938, 9939, 9940, 9941, 9942, 9943, 9944, 9945, 9946, 10066, 10067, 10068, 10069, 10070, 10071, 10072, 10073, 10074, 10193,
+                 10194, 10195, 10196, 10197, 10198, 10199, 10200, 10201, 10202, 10321, 10322, 10323, 10324, 10325, 10326, 10327, 10328, 10329, 10444, 10445, 10446, 10447, 10448, 10449, 10450,
+                 10451, 10452]
+
+check_md5: false
+check_size: false
+
+creators: [ 'Danila Korytov', 'Andrew Hearin',  'Eve Kovacs', 'Katrin Heitmann', 'Joe Hollowed', 'Patricia Larsen']
+
+description: |
+    This is the baseline catalog characterizing the galaxy-halo connection for LSST-DESC cosmoDC2.

--- a/GCRCatalogs/cosmodc2.py
+++ b/GCRCatalogs/cosmodc2.py
@@ -17,7 +17,7 @@ from GCR import BaseGenericCatalog
 from .utils import md5, first
 
 __all__ = ['CosmoDC2GalaxyCatalog', 'BaseDC2GalaxyCatalog', 'BaseDC2ShearCatalog', 'CosmoDC2AddonCatalog']
-__version__ = '1.0.0'
+__version__ = '1.1.2'
 
 CHECK_FILE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'catalog_configs/_cosmoDC2_check.yaml')
 
@@ -286,7 +286,8 @@ class CosmoDC2ParentClass(BaseGenericCatalog):
             with h5py.File(file_path, 'r') as fh:
                 for group in self._get_group_names(fh):
                     # pylint: disable=E1101,W0640
-                    yield lambda native_quantity: fh['{}/{}'.format(group, native_quantity)].value
+                    if len(fh[group]) > 0:
+                        yield lambda native_quantity: fh['{}/{}'.format(group, native_quantity)].value
 
     def _get_quantity_info_dict(self, quantity, default=None):
         q_mod = self.get_quantity_modifier(quantity)


### PR DESCRIPTION
This PR fixes a bug in the base class for the reader. The Nside=32 healpixels are small enough that at low z, sometimes the timestep is empty. The code needs to check if the group is empty before proceeding. Config files for the basedDC2 v1.1 catalogs have also been added.
