### PR TITLE
object catalog reader now provides fallback schema

### DIFF
--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -76,6 +76,8 @@ class TableWrapper():
     And a schema to specify dtypes and default values for missing columns.
     """
 
+    _default_values = {'i': -1, 'b': False}
+
     def __init__(self, file_handle, key, schema=None):
         if not file_handle.is_open:
             raise ValueError('file handle has been closed!')
@@ -135,10 +137,12 @@ class TableWrapper():
         If not found, default to np.float64 and np.nan.
         """
         schema_this = self._schema.get(key, {})
-        return self._generate_constant_array(
-            dtype=schema_this.get('dtype', np.float64),
-            value=schema_this.get('default', np.nan),
+        dtype = schema_this.get('dtype', np.float64)
+        default = schema_this.get(
+            'default',
+            self._default_values.get(np.dtype(dtype).kind, np.nan)
         )
+        return self._generate_constant_array(dtype=dtype, value=default)
 
     def _generate_constant_array(self, dtype, value):
         """

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -202,7 +202,7 @@ class ObjectTableWrapper(TableWrapper):
     def _get_default_value(cls, dtype, key=None):
         if np.dtype(dtype).kind == 'b' and key and (
                 key.endswith('_flag_bad') or key.endswith('_flag_noGoodPixels')):
-            return False
+            return True
         return super()._get_default_value(dtype, key)
 
     @property

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -525,7 +525,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
         if self._schema_path and os.path.isfile(self._schema_path):
             if not overwrite:
                 raise RuntimeError('Schema file `{}` already exists! Set `overwrite=True` to overwrite.'.format(self._schema_path))
-            warnings.warn('Overwriting schema file `{}`, which is backed up at `{}.bak`'.format(self._schema_path))
+            warnings.warn('Overwriting schema file `{0}`, which is backed up at `{0}.bak`'.format(self._schema_path))
             shutil.copyfile(self._schema_path, self._schema_path + '.bak')
 
         schema = self._generate_schema_from_datafiles(self._datasets)

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -200,7 +200,8 @@ class ObjectTableWrapper(TableWrapper):
 
     @classmethod
     def _get_default_value(cls, dtype, key=None):
-        if key and (key.endswith('_flag_bad') or key.endswith('_flag_noGoodPixels')):
+        if np.dtype(dtype).kind == 'b' and key and (
+                key.endswith('_flag_bad') or key.endswith('_flag_noGoodPixels')):
             return False
         return super()._get_default_value(dtype, key)
 
@@ -516,7 +517,8 @@ class DC2ObjectCatalog(BaseGenericCatalog):
 
         if default_values:
             for col, default in default_values.items():
-                schema[col]['default'] = default
+                if col in schema:
+                    schema[col]['default'] = default
 
         if write_to_yaml_path:
             with open(write_to_yaml_path, 'w') as schema_stream:

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -202,7 +202,7 @@ class ObjectTableWrapper(TableWrapper):
     def _get_default_value(cls, dtype, key=None):
         if key and (key.endswith('_flag_bad') or key.endswith('_flag_noGoodPixels')):
             return False
-        super()._get_default_value(dtype, key)
+        return super()._get_default_value(dtype, key)
 
     @property
     def tract_and_patch(self):

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -499,13 +499,11 @@ class DC2ObjectCatalog(BaseGenericCatalog):
         return schema
 
     @staticmethod
-    def _generate_schema_from_datafiles(datasets, default_values=None, write_to_yaml_path=None):
+    def _generate_schema_from_datafiles(datasets):
         """Return the native schema for given datasets
 
         Args:
             datasets (list): A list of tuples (<file path>, <key>)
-            default_values (dict): supply default values (`{col: default_value}`)
-            write_to_yaml_path (str): write out schema as a yaml file to this path
 
         Returns:
             A dict of schema ({col_name: {'dtype': dtype}}) found in all data sets
@@ -514,15 +512,6 @@ class DC2ObjectCatalog(BaseGenericCatalog):
         schema = {}
         for dataset in datasets:
             schema.update(dataset.native_schema)
-
-        if default_values:
-            for col, default in default_values.items():
-                if col in schema:
-                    schema[col]['default'] = default
-
-        if write_to_yaml_path:
-            with open(write_to_yaml_path, 'w') as schema_stream:
-                yaml.dump(schema, schema_stream)
 
         return schema
 

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -498,11 +498,13 @@ class DC2ObjectCatalog(BaseGenericCatalog):
         return schema
 
     @staticmethod
-    def _generate_schema_from_datafiles(datasets):
+    def _generate_schema_from_datafiles(datasets, default_values=None, write_to_yaml_path=None):
         """Return the native schema for given datasets
 
         Args:
             datasets (list): A list of tuples (<file path>, <key>)
+            default_values (dict): supply default values (`{col: default_value}`)
+            write_to_yaml_path (str): write out schema as a yaml file to this path
 
         Returns:
             A dict of schema ({col_name: {'dtype': dtype}}) found in all data sets
@@ -511,6 +513,14 @@ class DC2ObjectCatalog(BaseGenericCatalog):
         schema = {}
         for dataset in datasets:
             schema.update(dataset.native_schema)
+
+        if default_values:
+            for col, default in default_values.items():
+                schema[col]['default'] = default
+
+        if write_to_yaml_path:
+            with open(write_to_yaml_path, 'w') as schema_stream:
+                yaml.dump(schema, schema_stream)
 
         return schema
 

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -197,7 +197,7 @@ class ObjectTableWrapper(TableWrapper):
         # Add the schema info for tract, path
         # These values will be read by `get_constant_array`
         self._schema['tract'] = {'dtype': 'int64', 'default': self.tract}
-        self._schema['patch'] = {'dtype': '<U3', 'default': self.patch}
+        self._schema['patch'] = {'dtype': '<U', 'default': self.patch}
 
     @classmethod
     def _get_default_value(cls, dtype, key=None):


### PR DESCRIPTION
This PR updates the object catalog reader: If the schema yaml file is not available, the reader can now automatically generate the schema from the hdf5 data files as a fallback mechanism.

A bonus of this fallback feature is that we can actually use it to generate the schema yaml file, despite the fact that the schema yaml should really be generated by `merge_tract_cat.py`; see https://github.com/LSSTDESC/DC2-production/issues/292. To do so, one can simply run:

```python
import GCRCatalogs
for cat in ('dc2_object_run1.1p', 'dc2_object_run1.2i', 'dc2_object_run1.2i_all_columns'):
    GCRCatalogs.load_catalog(cat).generate_schema_yaml(overwrite=True)
```

@wmwv, once you approve this PR, I'll re-generate the schema yaml files by running the code snippet above.

With #226 and this PR, we fix #225. 