### PR TITLE
add DPDD-only object catalog 1.2p

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_dpdd_only.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_dpdd_only.yaml
@@ -1,0 +1,8 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/cscratch1/sd/plaszczy/Run1.2p/object_catalog
+schema_filename: dpdd_schema.yaml
+filename_pattern: 'dpdd_object_tract_\d+\.hdf5$'
+description: DC2 Run 1.2p Object Catalog (with DPDD columns only)
+creators: ['Stephane Plaszczynski']
+included_by_default: true
+is_dpdd: true

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -273,7 +273,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
             self._schema = self._generate_schema_from_datafiles(self._datasets)
 
         if kwargs.get('is_dpdd'):
-            self._quantity_modifiers = {col: col for col in self._schema}
+            self._quantity_modifiers = {col: None for col in self._schema}
             bands = [col[0] for col in self._schema if len(col) == 5 and col.startswith('mag_')]
 
         else:

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -274,6 +274,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
 
         if kwargs.get('is_dpdd'):
             self._quantity_modifiers = {col: col for col in self._schema}
+            bands = [col[0] for col in self._schema if len(col) == 5 and col.startswith('mag_')]
 
         else:
             # A slightly crude way of checking for version of schema to have modelfit mag

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -224,6 +224,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
                              Relative to base_dir, unless specified as absolute path.
     pixel_scale     (float): scale to convert pixel to arcsec (default: 0.2)
     use_cache        (bool): Whether or not to cache read data in memory
+    is_dpdd          (bool): Whether or not to the files are already in DPDD-format
 
     Attributes
     ----------
@@ -271,18 +272,21 @@ class DC2ObjectCatalog(BaseGenericCatalog):
             warnings.warn('Falling back to reading all datafiles for column names')
             self._schema = self._generate_schema_from_datafiles(self._datasets)
 
-        bands = [col[0] for col in self._schema if len(col) == 5 and col.endswith('_mag')]
+        if kwargs.get('is_dpdd'):
+            self._quantity_modifiers = {col: col for col in self._schema}
 
-        # A slightly crude way of checking for version of schema to have modelfit mag
-        # A future improvement will be to explicitly store version information in the datasets
-        # and just rely on that versioning.
-        has_modelfit_mag = any(col.endswith('_modelfit_mag') for col in self._schema)
-        if has_modelfit_mag:
-            self._schema_version = '1.2'
         else:
-            self._schema_version = '1.1'
+            # A slightly crude way of checking for version of schema to have modelfit mag
+            # A future improvement will be to explicitly store version information in the datasets
+            # and just rely on that versioning.
+            has_modelfit_mag = any(col.endswith('_modelfit_mag') for col in self._schema)
+            if has_modelfit_mag:
+                self._schema_version = '1.2'
+            else:
+                self._schema_version = '1.1'
+            bands = [col[0] for col in self._schema if len(col) == 5 and col.endswith('_mag')]
+            self._quantity_modifiers = self._generate_modifiers(self.pixel_scale, bands, version=self._schema_version)
 
-        self._quantity_modifiers = self._generate_modifiers(self.pixel_scale, bands, version=self._schema_version)
         self._quantity_info_dict = self._generate_info_dict(META_PATH, bands)
 
     def __del__(self):

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Confluence page (*DESC member only*).
    - `dc2_object_run1.2i`: static object catalog for Run 1.2i (with only DPDD columns and native columns needed for the DPDD columns)
    - `dc2_object_run1.2i_all_columns`: static object catalog for Run 1.2i (with DPDD and all native columns, slower to access)
    - `dc2_object_run1.2i_tract4850`: same as `dc2_object_run1.2i_all_columns` but only has one tract (4850)for testing purpose / faster access
+   - `dc2_object_run1.2p_dpdd_only`: static object catalog for Run 1.2p (with *only* DPDD columns)
    - `dc2_object_run1.1p`: static object catalog for Run 1.1p (with DPDD and all native columns)
    - `dc2_object_run1.1p_tract4850`: same as `dc2_object_run1.1p` but has only one tract (4850) for testing purpose / faster access
 


### PR DESCRIPTION
This PR adds the 1.2p object catalogs generated by @plaszczy. 

Because these catalogs have *only* DPDD columns, so the quantity modifiers defined in the object reader are not needed. Hence, this PR adds an `is_dpdd` option to skip the  generation of quantity modifiers in the original reader and use a set of trivial quantity modifiers instead.