### PR TITLE
Adds knots for version 1.1

### DIFF
--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.0_addon_knots.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.0_addon_knots.yaml
@@ -1,0 +1,14 @@
+subclass_name: composite.CompositeReader
+only_use_master_attr: true
+catalogs:
+  - catalog_name: cosmoDC2_v1.1
+  - catalog_name: knots
+    matching_method: MATCHING_FORMAT
+    subclass_name: cosmodc2.CosmoDC2AddonCatalog
+    catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/cosmoDC2_v1.1.0_knots_addon
+    catalog_filename_template: z_{}_{}.knots.healpix_{}.hdf5
+    addon_group: knots
+    check_cosmology: false
+    check_size: false
+    check_md5: false
+    check_version: false

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.0_addon_knots.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.0_addon_knots.yaml
@@ -1,7 +1,7 @@
 subclass_name: composite.CompositeReader
 only_use_master_attr: true
 catalogs:
-  - catalog_name: cosmoDC2_v1.1
+  - catalog_name: cosmoDC2_v1.1_image
   - catalog_name: knots
     matching_method: MATCHING_FORMAT
     subclass_name: cosmodc2.CosmoDC2AddonCatalog

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1_image.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1_image.yaml
@@ -1,0 +1,33 @@
+subclass_name: cosmodc2.CosmoDC2GalaxyCatalog
+
+catalog_root_dir: /global/projecta/projectdirs/lsst/groups/CS/cosmoDC2/cosmoDC2_v1.1.0
+catalog_filename_template: z_{}_{}.step_all.healpix_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+lightcone: true
+
+version: "1.1.0"
+
+check_md5: false
+
+healpix_pixels: [8786, 8787, 8788, 8789, 8790, 8791, 8792, 8793, 8794, 8913, 8914, 8915, 8916, 8917, 8918, 8919, 8920, 8921, 9042, 9043, 9044, 9045, 9046, 9047, 9048, 9049,
+                 9050, 9169, 9170, 9171, 9172, 9173, 9174, 9175, 9176, 9177, 9178, 9298, 9299, 9300, 9301, 9302, 9303, 9304, 9305, 9306, 9425, 9426, 9427, 9428, 9429, 9430,
+                 9431, 9432, 9433, 9434, 9554, 9555, 9556, 9557, 9558, 9559, 9560, 9561, 9562, 9681, 9682, 9683, 9684, 9685, 9686, 9687, 9688, 9689, 9690, 9810, 9811, 9812,
+                 9813, 9814, 9815, 9816, 9817, 9818, 9937, 9938, 9939, 9940, 9941, 9942, 9943, 9944, 9945, 9946, 10066, 10067, 10068, 10069, 10070, 10071, 10072, 10073, 10074, 10193,
+                 10194, 10195, 10196, 10197, 10198, 10199, 10200, 10201, 10202, 10321, 10322, 10323, 10324, 10325, 10326, 10327, 10328, 10329, 10444, 10445, 10446, 10447, 10448, 10449, 10450,
+                 10451, 10452]
+
+check_size: false
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
+
+description: |
+    This is the extra-galactic catalog for the LSST-DESC data challenge DC2.
+
+included_by_default: true


### PR DESCRIPTION
This PR just adds a catalog config for the new knots catalog sampled for cosmoDC2 v1.1