### PR TITLE
Issues/246

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
@@ -1,5 +1,5 @@
 subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_new
 schema_filename: trim_schema.yaml
 filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
@@ -5,4 +5,4 @@ filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog
 creators: ['Michael Wood-Vasey']
 included_by_default: true
-pixel_scale: 0.185
+pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
@@ -5,4 +5,4 @@ filename_pattern: 'object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog
 creators: ['Michael Wood-Vasey']
 included_by_default: true
-pixel_scale: 0.185
+pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
@@ -1,5 +1,5 @@
 subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_new
 schema_filename: schema.yaml
 filename_pattern: 'object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha.yaml
@@ -5,4 +5,4 @@ filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog - Prototype Processing
 creators: ['Michael Wood-Vasey']
 included_by_default: true
-pixel_scale: 0.185
+pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha.yaml
@@ -1,0 +1,8 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_alpha
+schema_filename: trim_schema.yaml
+filename_pattern: 'trim_object_tract_\d+\.hdf5$'
+description: DC2 Run 1.2i Object Catalog - Prototype Processing
+creators: ['Michael Wood-Vasey']
+included_by_default: true
+pixel_scale: 0.185

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha_all_columns.yaml
@@ -1,0 +1,8 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_alpha
+schema_filename: schema.yaml
+filename_pattern: 'object_tract_\d+\.hdf5$'
+description: DC2 Run 1.2i Object Catalog - Prototype Processing
+creators: ['Michael Wood-Vasey']
+included_by_default: true
+pixel_scale: 0.185

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha_all_columns.yaml
@@ -5,4 +5,4 @@ filename_pattern: 'object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog - Prototype Processing
 creators: ['Michael Wood-Vasey']
 included_by_default: true
-pixel_scale: 0.185
+pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract4850.yaml
@@ -4,4 +4,4 @@ filename_pattern: 'object_tract_4850\.hdf5$'
 description: 'DC2 Run 1.2i Object Catalog Tract 4850'
 creators: ['Michael Wood-Vasey']
 included_by_default: true
-pixel_scale: 0.185
+pixel_scale: 0.2


### PR DESCRIPTION
Defines `dc2_object_run1.2i` to point to `object_catalog_new` and
`dc2_object_run1.2i_alpha` to point to `object_catalog_alpha`.

`object_catalog_new` contains the re-processed Run 1.2i that now includes the full object catalog from all of the bands in the co-adds.

The present behavior is that `dc2_object_run1.2i` points to `object_catalog`, which points to `object_catalog_alpha` through a file system symlink.  To preserve consistency of behavior within a released DESC Python version on NERSC, I plan to maintain that symlink until the commits in this present branch are tagged and installed on NERSC.  At that point I will update the symlink -- although it shouldn't directly affect the user experience it will improve ease of human reading in that directory.