### PR TITLE
Do not display Run 1.2i alpha object catalogs by default

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha.yaml
@@ -4,5 +4,4 @@ schema_filename: trim_schema.yaml
 filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog - Prototype Processing
 creators: ['Michael Wood-Vasey']
-included_by_default: true
 pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_alpha_all_columns.yaml
@@ -4,5 +4,4 @@ schema_filename: schema.yaml
 filename_pattern: 'object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog - Prototype Processing
 creators: ['Michael Wood-Vasey']
-included_by_default: true
 pixel_scale: 0.2


### PR DESCRIPTION
This PR removes `dc2_object_run1.2i_alpha` and `dc2_object_run1.2i_alpha_all_columns` from the default listing.