### PR TITLE
Issues/256

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p.yaml
@@ -1,8 +1,8 @@
 subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
 schema_filename: trim_schema.yaml
-filename_pattern: 'trim_merged_tract_\d+\.hdf5$'
+filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2p Object Catalog DPDD-columns (with only DPDD columns and native columns needed for the DPDD columns)
-creators: ['Stephane Plaszczynski']
+creators: ['Micahel Wood-Vasey']
 included_by_default: true
-pixel_scale: 0.185
+pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p.yaml
@@ -1,8 +1,2 @@
-subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
-schema_filename: trim_schema.yaml
-filename_pattern: 'trim_object_tract_\d+\.hdf5$'
-description: DC2 Run 1.2p Object Catalog DPDD-columns (with only DPDD columns and native columns needed for the DPDD columns)
-creators: ['Micahel Wood-Vasey']
+alias: dc2_object_run1.2p_v4
 included_by_default: true
-pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_all_columns.yaml
@@ -1,6 +1,2 @@
-subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
-description: DC2 Run 1.2p Object Catalog
-creators: ['Michael Wood-Vasey']
+alias: dc2_object_run1.2p_v4_all_columns
 included_by_default: true
-pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_all_columns.yaml
@@ -1,6 +1,6 @@
 subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
 description: DC2 Run 1.2p Object Catalog
-creators: ['Stephane Plaszczynski']
+creators: ['Michael Wood-Vasey']
 included_by_default: true
-pixel_scale: 0.185
+pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_tract4850.yaml
@@ -1,7 +1,7 @@
 subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog
-filename_pattern: 'merged_tract_4850\.hdf5$'
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
+filename_pattern: 'object_tract_4850\.hdf5$'
 description: 'DC2 Run 1.2p Object Catalog Tract 4850'
-creators: ['Stephane Plaszczynski']
+creators: ['Michael Wood-Vasey']
 included_by_default: true
-pixel_scale: 0.185
+pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_tract4850.yaml
@@ -1,7 +1,2 @@
-subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
-filename_pattern: 'object_tract_4850\.hdf5$'
-description: 'DC2 Run 1.2p Object Catalog Tract 4850'
-creators: ['Michael Wood-Vasey']
+alias: dc2_object_run1.2p_v4_tract4850
 included_by_default: true
-pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3.yaml
@@ -4,5 +4,4 @@ schema_filename: trim_schema.yaml
 filename_pattern: 'trim_merged_tract_\d+\.hdf5$'
 description: DC2 Run 1.2p Object Catalog DPDD-columns (with only DPDD columns and native columns needed for the DPDD columns)
 creators: ['Stephane Plaszczynski']
-included_by_default: true
 pixel_scale: 0.185

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3.yaml
@@ -1,0 +1,8 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v3
+schema_filename: trim_schema.yaml
+filename_pattern: 'trim_merged_tract_\d+\.hdf5$'
+description: DC2 Run 1.2p Object Catalog DPDD-columns (with only DPDD columns and native columns needed for the DPDD columns)
+creators: ['Stephane Plaszczynski']
+included_by_default: true
+pixel_scale: 0.185

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_all_columns.yaml
@@ -1,0 +1,6 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v3
+description: DC2 Run 1.2p Object Catalog
+creators: ['Stephane Plaszczynski']
+included_by_default: true
+pixel_scale: 0.185

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_all_columns.yaml
@@ -2,5 +2,4 @@ subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v3
 description: DC2 Run 1.2p Object Catalog
 creators: ['Stephane Plaszczynski']
-included_by_default: true
 pixel_scale: 0.185

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_tract4850.yaml
@@ -1,0 +1,7 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v3
+filename_pattern: 'merged_tract_4850\.hdf5$'
+description: 'DC2 Run 1.2p Object Catalog Tract 4850'
+creators: ['Stephane Plaszczynski']
+included_by_default: true
+pixel_scale: 0.185

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_tract4850.yaml
@@ -3,5 +3,4 @@ base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_
 filename_pattern: 'merged_tract_4850\.hdf5$'
 description: 'DC2 Run 1.2p Object Catalog Tract 4850'
 creators: ['Stephane Plaszczynski']
-included_by_default: true
 pixel_scale: 0.185

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4.yaml
@@ -1,0 +1,8 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
+schema_filename: trim_schema.yaml
+filename_pattern: 'trim_merged_tract_\d+\.hdf5$'
+description: DC2 Run 1.2p Object Catalog DPDD-columns (with only DPDD columns and native columns needed for the DPDD columns)
+creators: ['Micahel Wood-Vasey']
+included_by_default: true
+pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4.yaml
@@ -4,5 +4,4 @@ schema_filename: trim_schema.yaml
 filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2p Object Catalog DPDD-columns (with only DPDD columns and native columns needed for the DPDD columns)
 creators: ['Micahel Wood-Vasey']
-included_by_default: true
 pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4.yaml
@@ -1,7 +1,7 @@
 subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
 schema_filename: trim_schema.yaml
-filename_pattern: 'trim_merged_tract_\d+\.hdf5$'
+filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2p Object Catalog DPDD-columns (with only DPDD columns and native columns needed for the DPDD columns)
 creators: ['Micahel Wood-Vasey']
 included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4_all_columns.yaml
@@ -2,5 +2,4 @@ subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
 description: DC2 Run 1.2p Object Catalog
 creators: ['Michael Wood-Vasey']
-included_by_default: true
 pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4_all_columns.yaml
@@ -1,0 +1,6 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
+description: DC2 Run 1.2p Object Catalog
+creators: ['Michael Wood-Vasey']
+included_by_default: true
+pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4_tract4850.yaml
@@ -1,6 +1,6 @@
 subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
-filename_pattern: 'merged_tract_4850\.hdf5$'
+filename_pattern: 'object_tract_4850\.hdf5$'
 description: 'DC2 Run 1.2p Object Catalog Tract 4850'
 creators: ['Michael Wood-Vasey']
 included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4_tract4850.yaml
@@ -3,5 +3,4 @@ base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_
 filename_pattern: 'object_tract_4850\.hdf5$'
 description: 'DC2 Run 1.2p Object Catalog Tract 4850'
 creators: ['Michael Wood-Vasey']
-included_by_default: true
 pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v4_tract4850.yaml
@@ -1,0 +1,7 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2p/object_catalog_v4
+filename_pattern: 'merged_tract_4850\.hdf5$'
+description: 'DC2 Run 1.2p Object Catalog Tract 4850'
+creators: ['Michael Wood-Vasey']
+included_by_default: true
+pixel_scale: 0.2


### PR DESCRIPTION
Add Run1.2p v4 re-processing.  Defines v3 retroactively.

Update general `dc2_object_run1.2p` to refer to v4.

Will re-point the symlink on NERSC when this change is put into the next release.