### PR TITLE
Issues/254

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract4850.yaml
@@ -1,5 +1,5 @@
 subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run1.2i/object_catalog_new
 filename_pattern: 'object_tract_4850\.hdf5$'
 description: 'DC2 Run 1.2i Object Catalog Tract 4850'
 creators: ['Michael Wood-Vasey']

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -364,6 +364,9 @@ class DC2ObjectCatalog(BaseGenericCatalog):
             modifiers['psFluxErr_{}'.format(band)] = '{}_base_PsfFlux_{}{}'.format(band, FLUX, ERR)
             modifiers['I_flag_{}'.format(band)] = '{}_base_SdssShape_flag'.format(band)
 
+            modifiers['cModelFlux_{}'.format(band)] = '{}_modelfit_CModel_{}'.format(band, FLUX)
+            modifiers['cModelFluxErr_{}'.format(band)] = '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR)
+
             for ax in ['xx', 'yy', 'xy']:
                 modifiers['I{}_{}'.format(ax, band)] = '{}_base_SdssShape_{}'.format(band, ax)
                 modifiers['I{}PSF_{}'.format(ax, band)] = '{}_base_SdssShape_psf_{}'.format(band, ax)

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -366,6 +366,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
 
             modifiers['cModelFlux_{}'.format(band)] = '{}_modelfit_CModel_{}'.format(band, FLUX)
             modifiers['cModelFluxErr_{}'.format(band)] = '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR)
+            modifiers['cModelFlux_flag_{}'.format(band)] = '{}_modelfit_CModel_flag'.format(band)
 
             for ax in ['xx', 'yy', 'xy']:
                 modifiers['I{}_{}'.format(ax, band)] = '{}_base_SdssShape_{}'.format(band, ax)


### PR DESCRIPTION
Adding cModelFlux, cModelFluxErr to gcr-catalogs is a trivial two-line change.

I snuck in a fix to the Run 1.2i tract_4850 YAML config as well.  Not formally part of this tick.  But I ran across it while implementing and testing and figured I'd just include it here as well.

I have also updated at NERSC the trim catalogs and DPDD Parquet files.