### PR TITLE
update truth variable summary catalog and reader (with hdf5 file)

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.2_variable_summary.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.2_variable_summary.yaml
@@ -1,8 +1,6 @@
-subclass_name: dc2_truth.DC2TruthCatalogReader
+subclass_name: dc2_truth.DC2TruthLCSummaryReader
 
-filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/Run1.2/run_1.2_trial_light_curves_181004.db
-table_name: variables_and_transients
-is_static: False
+filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/Run1.2/run1p2_light_curve_reference_190311.h5
 
 description: |
     Truth catalog for Run 1.2, summary table for variable objects.

--- a/GCRCatalogs/dc2_truth.py
+++ b/GCRCatalogs/dc2_truth.py
@@ -2,6 +2,7 @@ import os
 import sqlite3
 import numpy as np
 import h5py
+import warnings
 from GCR import BaseGenericCatalog
 from GCR import GCRQuery
 from .utils import md5, is_string_like
@@ -62,26 +63,12 @@ class DC2TruthLCSummaryReader(BaseGenericCatalog):
             return list(file_handle.keys())
 
     def _iter_native_dataset(self, native_filters=None):
-        names_to_filter = []
         if native_filters is not None:
-            for name in native_filters.variable_names:
-                print('filtering %s' % name)
-                names_to_filter.append(name)
-
+            warnings.warn("Native filters are not implemented "
+                          "for this catalog; just use filters.")
         with h5py.File(self._file_name, 'r') as file_handle:
-            filter_dict = {}
-            valid = None
-            if native_filters is not None:
-                for name in names_to_filter:
-                    filter_dict[name] = file_handle[name].value
-                valid = native_filters.check_scalar(filter_dict)
-                del filter_dict
-
             def _native_qty_getter(qty_name):
-                output = file_handle[qty_name].value
-                if valid is not None:
-                    output = output[valid]
-                return output
+                return file_handle[qty_name].value
             yield _native_qty_getter
 
 

--- a/GCRCatalogs/dc2_truth.py
+++ b/GCRCatalogs/dc2_truth.py
@@ -51,10 +51,8 @@ class DC2TruthLCSummaryReader(BaseGenericCatalog):
                    'description': 'an int that is 1 if the object was '
                    'added by the sprinkler; 0 otherwise.'}
 
-    def get_quantity_info(self, qty_name):
-        if qty_name not in self._info_dict:
-            return None
-        return self._info_dict[qty_name]
+    def _get_quantity_info(self, qty_name, default=None):
+        return self._info_dict.get(quantity, default)
 
     def _generate_native_quantity_list(self):
         with h5py.File(self._file_name, 'r') as file_handle:

--- a/GCRCatalogs/dc2_truth.py
+++ b/GCRCatalogs/dc2_truth.py
@@ -4,7 +4,6 @@ import numpy as np
 import h5py
 import warnings
 from GCR import BaseGenericCatalog
-from GCR import GCRQuery
 from .utils import md5, is_string_like
 
 __all__ = ['DC2TruthCatalogReader', 'DC2TruthCatalogLightCurveReader',
@@ -24,7 +23,6 @@ class DC2TruthLCSummaryReader(BaseGenericCatalog):
 
     def _subclass_init(self, **kwargs):
         self._file_name = kwargs['filename']
-        self._native_filter_quantities = {'redshift', 'agn', 'sn', 'sprinkled'}
 
         self._info_dict = {}
         self._info_dict['redshift'] = {'units': 'unitless'}

--- a/GCRCatalogs/dc2_truth.py
+++ b/GCRCatalogs/dc2_truth.py
@@ -25,6 +25,38 @@ class DC2TruthLCSummaryReader(BaseGenericCatalog):
         self._file_name = kwargs['filename']
         self._native_filter_quantities = {'redshift', 'agn', 'sn', 'sprinkled'}
 
+        self._info_dict = {}
+        self._info_dict['redshift'] = {'units': 'unitless'}
+        self._info_dict['ra'] = {'units': 'degrees'}
+        self._info_dict['dec'] = {'units': 'degrees'}
+        self._info_dict['uniqueId'] = {'units': 'unitless',
+                     'description': 'an int uniquely identifying the object. '
+                     'Does NOT correspond to galaxy_id in the extra-galactic '
+                     'catalog.'}
+
+        self._info_dict['galaxy_id'] = {'units': 'unitless',
+                       'description':
+                       'should correspond to galaxy_id in the extra-galactic '
+                       'catalog.  Note: sprinkled objects and all supernovae '
+                       'will not have sensible values of galaxy_id.'}
+
+        self._info_dict['agn'] = {'units': 'unitless',
+                    'description': 'an int that is 1 for AGN and 0 for '
+                    'all other objects.'}
+
+        self._info_dict['sn'] = {'units': 'unitless',
+                  'description': 'an int that is 1 for supernovae and 0 for '
+                  'all other objects'}
+
+        self._info_dict['sprinkled'] = {'units': 'unitless',
+                   'description': 'an int that is 1 if the object was '
+                   'added by the sprinkler; 0 otherwise.'}
+
+    def get_quantity_info(self, qty_name):
+        if qty_name not in self._info_dict:
+            return None
+        return self._info_dict[qty_name]
+
     def _generate_native_quantity_list(self):
         with h5py.File(self._file_name, 'r') as file_handle:
             return list(file_handle.keys())

--- a/GCRCatalogs/dc2_truth.py
+++ b/GCRCatalogs/dc2_truth.py
@@ -51,7 +51,7 @@ class DC2TruthLCSummaryReader(BaseGenericCatalog):
                    'description': 'an int that is 1 if the object was '
                    'added by the sprinkler; 0 otherwise.'}
 
-    def _get_quantity_info(self, qty_name, default=None):
+    def _get_quantity_info(self, quantity, default=None):
         return self._info_dict.get(quantity, default)
 
     def _generate_native_quantity_list(self):


### PR DESCRIPTION
This should address the problem identified here

https://github.com/LSSTDESC/gcr-catalogs/issues/272

specifically, that there is no reliable way to get truth redshifts for SNe in run 1.2