### PR TITLE
Adding `members_only` option for redmapper catalogs

### DIFF
--- a/GCRCatalogs/catalog_configs/proto-dc2_v3.0_addon_redmapper.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v3.0_addon_redmapper.yaml
@@ -1,7 +1,7 @@
 subclass_name: composite.CompositeReader
 catalogs:
-  - catalog_name: proto-dc2_v3.0_test
-    matching_method: galaxyID
   - catalog_name: proto-dc2_v3.0_redmapper
     matching_method: galaxy_id
     members_only: true
+  - catalog_name: proto-dc2_v3.0_test
+    matching_method: galaxyID

--- a/GCRCatalogs/catalog_configs/proto-dc2_v3.0_addon_redmapper.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v3.0_addon_redmapper.yaml
@@ -4,3 +4,4 @@ catalogs:
     matching_method: galaxyID
   - catalog_name: proto-dc2_v3.0_redmapper
     matching_method: galaxy_id
+    members_only: true

--- a/GCRCatalogs/catalog_configs/proto-dc2_v4.3_addon_redmapper.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v4.3_addon_redmapper.yaml
@@ -4,3 +4,4 @@ catalogs:
     matching_method: galaxy_id
   - catalog_name: proto-dc2_v4.3_redmapper
     matching_method: galaxy_id
+    members_only: true

--- a/GCRCatalogs/catalog_configs/proto-dc2_v4.3_addon_redmapper.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v4.3_addon_redmapper.yaml
@@ -1,7 +1,7 @@
 subclass_name: composite.CompositeReader
 catalogs:
-  - catalog_name: proto-dc2_v4.3_test
-    matching_method: galaxy_id
   - catalog_name: proto-dc2_v4.3_redmapper
     matching_method: galaxy_id
     members_only: true
+  - catalog_name: proto-dc2_v4.3_test
+    matching_method: galaxy_id

--- a/GCRCatalogs/composite.py
+++ b/GCRCatalogs/composite.py
@@ -3,7 +3,7 @@ composite reader
 """
 import warnings
 from GCR import CompositeCatalog, MATCHING_FORMAT, MATCHING_ORDER
-from .register import load_catalog, load_catalog_from_config_dict
+from .register import load_catalog, load_catalog_from_config_dict, available_catalogs
 
 class CompositeReader(CompositeCatalog):
     def __init__(self, **kwargs):
@@ -11,10 +11,11 @@ class CompositeReader(CompositeCatalog):
         identifiers = []
         methods = []
         for catalog_dict in kwargs['catalogs']:
-            if 'subclass_name' in catalog_dict:
-                catalog = load_catalog_from_config_dict(catalog_dict)
+            catalog_name = catalog_dict.get('catalog_name')
+            if catalog_name in available_catalogs:
+                catalog = load_catalog(catalog_name, catalog_dict)
             else:
-                catalog = load_catalog(catalog_dict['catalog_name'])
+                catalog = load_catalog_from_config_dict(catalog_dict)
             instances.append(catalog)
             identifiers.append(catalog_dict.get('catalog_name'))
             method = catalog_dict.get('matching_method', 'MATCHING_FORMAT')


### PR DESCRIPTION
A redmapper catalog contains both members information and clusters information, and obviously they would have different number of rows (unless every cluster has only one member, but we don't live in that universe).

GCR by itself does not requires all columns have the same number of rows, and hence the redmapper reader work fine as it. A column of "members" table just have different number of rows from a column of "clusters" table. 

However, when matching the redmapper catalog to the underlying protoDC2 catalog, the matched catalog can have only one single table, and in this case, it's the members table that is needed (i.e., each "member", not "cluster", in the redmapper catalog corresponds to a  galaxy in the protoDC2 catalog). 

Hence, this PR introduces a `members_only` option so that when the redmapper catalog is used as an "add-on", only the members part is matched to the protoDC2 catalog. 

This PR fixes #315. 