### PR TITLE
fix eimages catalog paths

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_eimages_run1.2i_visit-181898.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_eimages_run1.2i_visit-181898.yaml
@@ -1,5 +1,5 @@
 subclass_name: eimage.EImageReader
-root_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/DC2-R1-2p-WFD-r
+root_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run1.2i/eimages/DC2-R1-2p-WFD-r
 dirpath_contain: 000008_batch
 visits: 181898
 default_rebinning: 16

--- a/GCRCatalogs/catalog_configs/dc2_eimages_run1.2p_visit-181898.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_eimages_run1.2p_visit-181898.yaml
@@ -1,5 +1,5 @@
 subclass_name: eimage.EImageReader
-root_dir: /global/projecta/projectdirs/lsst/global/DC2/DC2-R1-2p-WFD-r/000008
+root_dir: /global/projecta/projectdirs/lsst/production/DC2_PhoSim/Run1.2p/eimages/DC2-R1-2p-WFD-r/output/000008
 visits: 181898
 default_rebinning: 16
 description: phoSim e-images for Run 1.2p (visit 181898)


### PR DESCRIPTION
DC2 eimages catalog paths are outdated. This PR updates them. 