### PR TITLE
Add photo-z mag err catalog reader

### DIFF
--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_photoz_magerr_10y.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_photoz_magerr_10y.yaml
@@ -1,0 +1,10 @@
+subclass_name: composite.CompositeReader
+only_use_master_attr: true
+catalogs:
+  - catalog_name: cosmoDC2_v1.1.4_small
+  - catalog_name: photoz_magerr_10y_estimate
+    matching_method: MATCHING_FORMAT
+    subclass_name: photoz_magerr.PZMagErrCatalog
+    base_dir: /global/projecta/projectdirs/lsst/groups/PZ/PhotoZDC2/COSMODC2v1.1.4/10_year_error_estimates
+    creators: ['Sam Schmidt']
+    healpix_pixels: [9559,  9686,  9687,  9814,  9815,  9816,  9942,  9943, 10070, 10071, 10072, 10198, 10199, 10200, 10326, 10327, 10450]

--- a/GCRCatalogs/photoz_magerr.py
+++ b/GCRCatalogs/photoz_magerr.py
@@ -1,0 +1,47 @@
+"""
+PZ mag err catalog (matched to cosmoDC2) reader
+
+This reader was designed by Yao-Yuan Mao,
+based a catalog provided by Sam Schmidt.
+"""
+
+import re
+import os
+import pandas as pd
+from GCR import BaseGenericCatalog
+
+from .utils import first
+
+__all__ = ['PZMagErrCatalog']
+
+FILE_PATTERN = r'z_(\d)\S+healpix_(\d+)_magwerr\.h5$'
+
+class PZMagErrCatalog(BaseGenericCatalog):
+
+    def _subclass_init(self, **kwargs):
+        self.base_dir = kwargs['base_dir']
+        self._filename_re = re.compile(kwargs.get('filename_pattern', FILE_PATTERN))
+        self._healpix_pixels = kwargs.get('healpix_pixels')
+
+        self._healpix_files = dict()
+        for f in sorted(os.listdir(self.base_dir)):
+            m = self._filename_re.match(f)
+            if m is None:
+                continue
+            key = tuple(map(int, m.groups()))
+            if self._healpix_pixels and key[1] not in self._healpix_pixels:
+                continue
+            self._healpix_files[key] = os.path.join(self.base_dir, f)
+
+        self._native_filter_quantities = {'healpix_pixel', 'redshift_block_lower'}
+
+    def _generate_native_quantity_list(self):
+        return pd.read_hdf(first(self._healpix_files.values())).columns.tolist()
+
+    def _iter_native_dataset(self, native_filters=None):
+        for (zlo_this, hpx_this), file_path in self._healpix_files.items():
+            d = {'healpix_pixel': hpx_this, 'redshift_block_lower': zlo_this}
+            if native_filters is not None and not native_filters.check_scalar(d):
+                continue
+            df = pd.read_hdf(file_path)
+            yield lambda col: df[col].values # pylint: disable=cell-var-from-loop


### PR DESCRIPTION
This PR adds a photo-z magnitude error estimate catalog reader (the catalog matches to cosmoDC2) and the corresponding catalog config.

The catalog data are provided by @sschmidt23. @sschmidt23 can you double check if the reader is implemented correctly and also suggest descriptions when appropriate? 

@MarkusMichaelRau, can you check out this branch and test the reader to see if it works as needed? 

Thank you both.

--
Also, we now have 3 different readers for 3 different photo-z products, and have 4 different readers for 4 different cosmoDC2 add-ons. We need to an unified format to prevent reader proliferation, which is already taking place (cc @wmwv).