### PR TITLE
update default catalog list

### DIFF
--- a/GCRCatalogs/catalog_configs/baseDC2_snapshot_z0.15_v0.1.yaml
+++ b/GCRCatalogs/catalog_configs/baseDC2_snapshot_z0.15_v0.1.yaml
@@ -10,8 +10,6 @@ cosmology:
     n_s: 0.963
     sigma8: 0.8
 
-
-
 lightcone: false
 
 version: "0.1.0"

--- a/GCRCatalogs/catalog_configs/baseDC2_snapshot_z0.15_v0.1_small.yaml
+++ b/GCRCatalogs/catalog_configs/baseDC2_snapshot_z0.15_v0.1_small.yaml
@@ -10,8 +10,6 @@ cosmology:
     n_s: 0.963
     sigma8: 0.8
 
-
-
 blocks: [0, 1]
 
 lightcone: false

--- a/GCRCatalogs/catalog_configs/baseDC2_snapshot_z1.01_v0.1.yaml
+++ b/GCRCatalogs/catalog_configs/baseDC2_snapshot_z1.01_v0.1.yaml
@@ -10,8 +10,6 @@ cosmology:
     n_s: 0.963
     sigma8: 0.8
 
-
-
 lightcone: false
 
 version: "0.1.0"

--- a/GCRCatalogs/catalog_configs/buzzard.yaml
+++ b/GCRCatalogs/catalog_configs/buzzard.yaml
@@ -1,2 +1,2 @@
 alias: buzzard_v1.9.2_3
-included_by_default: true
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/buzzard_high-res.yaml
+++ b/GCRCatalogs/catalog_configs/buzzard_high-res.yaml
@@ -1,2 +1,2 @@
 alias: buzzard_high-res_v1.1
-included_by_default: true
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/buzzard_test.yaml
+++ b/GCRCatalogs/catalog_configs/buzzard_test.yaml
@@ -1,2 +1,1 @@
 alias: buzzard_v1.9.2_test
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/cosmoDC2.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2.yaml
@@ -1,2 +1,2 @@
-alias: dc2_object_run1.2p_v4
+alias: cosmoDC2_v1.1.4_image
 include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0.yaml
@@ -20,5 +20,3 @@ creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'P
 
 description: |
     This is the extra-galactic catalog for the LSST-DESC data challenge DC2.
-
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_image.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_image.yaml
@@ -28,4 +28,3 @@ creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'P
 description: |
     This is the extra-galactic catalog used in image simulations for the LSST-DESC data challenge DC2.
 
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_small.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.0_small.yaml
@@ -1,2 +1,1 @@
 alias: cosmoDC2_v1.0_9431_9812
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image.yaml
@@ -28,4 +28,3 @@ creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'P
 description: |
     This is the extra-galactic catalog for the LSST-DESC data challenge DC2.
 
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small.yaml
@@ -25,4 +25,3 @@ creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'P
 description: |
     This is the extra-galactic catalog for the LSST-DESC data challenge DC2.
 
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_dia_source_run1.2p_test.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_dia_source_run1.2p_test.yaml
@@ -4,4 +4,3 @@ schema_filename: schema.yaml
 filename_pattern: 'dia_src_visit_\d+\.parquet$'
 description: DC2 Run 1.2p DIA Source Catalog test patch
 creators: ['Michael Wood-Vasey']
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_forced_source_run1.2p.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_forced_source_run1.2p.yaml
@@ -4,4 +4,3 @@ schema_filename: schema.yaml
 filename_pattern: 'forced_src_visit_\d+\.parquet$'
 description: DC2 Run 1.2p Forced Source Catalog
 creators: ['Michael Wood-Vasey']
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_metacal_run1.2i_tract5063.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_metacal_run1.2i_tract5063.yaml
@@ -4,6 +4,5 @@ schema_filename: schema.yaml
 filename_pattern: 'metacal_tract_\d+\.parquet$'
 description: DC2 Run 1.2i Metacal Catalog
 creators: ['Francois Lanusse', 'Johann Cohen-Tanugi']
-included_by_default: true
 bands: 'riz'
 apply_metacal_test3_fix: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.1p.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.1p.yaml
@@ -2,5 +2,5 @@ subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/production/DC2_PhoSim/Run1.1p/dpdd/object_catalog
 description: DC2 Run 1.1p Object Catalog
 creators: ['Michael Wood-Vasey']
-included_by_default: true
 pixel_scale: 0.185
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.1p_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.1p_tract4850.yaml
@@ -3,5 +3,4 @@ base_dir: /global/projecta/projectdirs/lsst/production/DC2_PhoSim/Run1.1p/dpdd/o
 filename_pattern: '(?:merged|object)_tract_4850\.hdf5$'
 description: DC2 Run 1.1p Object Catalog
 creators: ['Michael Wood-Vasey']
-included_by_default: true
 pixel_scale: 0.185

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i.yaml
@@ -4,5 +4,5 @@ schema_filename: trim_schema.yaml
 filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog
 creators: ['Michael Wood-Vasey']
-included_by_default: true
 pixel_scale: 0.2
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns.yaml
@@ -4,5 +4,4 @@ schema_filename: schema.yaml
 filename_pattern: 'object_tract_\d+\.hdf5$'
 description: DC2 Run 1.2i Object Catalog
 creators: ['Michael Wood-Vasey']
-included_by_default: true
 pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns_with_photoz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_all_columns_with_photoz.yaml
@@ -5,4 +5,3 @@ catalogs:
     matching_method: MATCHING_FORMAT
   - catalog_name: photoz_dc2_object_run1.2i
     matching_method: MATCHING_FORMAT
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract4850.yaml
@@ -3,5 +3,4 @@ base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run1.2i/dpdd/ob
 filename_pattern: 'object_tract_4850\.hdf5$'
 description: 'DC2 Run 1.2i Object Catalog Tract 4850'
 creators: ['Michael Wood-Vasey']
-included_by_default: true
 pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract5063.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract5063.yaml
@@ -3,5 +3,4 @@ base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run1.2i/dpdd/ob
 filename_pattern: 'object_tract_5063\.hdf5$'
 description: 'DC2 Run 1.2i Object Catalog Tract 5063'
 creators: ['Michael Wood-Vasey']
-included_by_default: true
 pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract5063_with_metacal.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_tract5063_with_metacal.yaml
@@ -5,4 +5,3 @@ catalogs:
     matching_method: 'id'
   - catalog_name: dc2_object_run1.2i_tract5063
     matching_method: 'id'
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2i_with_photoz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2i_with_photoz.yaml
@@ -5,4 +5,3 @@ catalogs:
     matching_method: MATCHING_FORMAT
   - catalog_name: photoz_dc2_object_run1.2i
     matching_method: MATCHING_FORMAT
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_all_columns.yaml
@@ -1,2 +1,1 @@
 alias: dc2_object_run1.2p_v4_all_columns
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_tract4850.yaml
@@ -1,2 +1,1 @@
 alias: dc2_object_run1.2p_v4_tract4850
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_all_columns_with_photoz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_all_columns_with_photoz.yaml
@@ -5,4 +5,3 @@ catalogs:
     matching_method: MATCHING_FORMAT
   - catalog_name: photoz_dc2_object_run1.2p_v3
     matching_method: MATCHING_FORMAT
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_with_photoz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run1.2p_v3_with_photoz.yaml
@@ -5,4 +5,3 @@ catalogs:
     matching_method: MATCHING_FORMAT
   - catalog_name: photoz_dc2_object_run1.2p_v3
     matching_method: MATCHING_FORMAT
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_source_run1.2i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_source_run1.2i.yaml
@@ -4,4 +4,3 @@ schema_filename: schema.yaml
 filename_pattern: 'src_visit_\d+\.parquet$'
 description: DC2 Run 1.2i Source Catalog
 creators: ['Michael Wood-Vasey']
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.1_static.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.1_static.yaml
@@ -11,4 +11,4 @@ description: |
     variability model is layered.  This truth information was generated with
     version 2.1.2 of the proto-DC2 extragalactic catalog.
 
-included_by_default: true
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.2_static.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.2_static.yaml
@@ -1,1 +1,2 @@
 alias: dc2_truth_run1.2_static_no_extinction
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.2_static_galaxies.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.2_static_galaxies.yaml
@@ -4,5 +4,3 @@ filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/Run1.2/run1p2_static
 
 description: |
     Truth catalog for Run 1.2. Static objects (galaxies only).
-
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.2_static_no_extinction.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.2_static_no_extinction.yaml
@@ -5,5 +5,3 @@ filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/Run1.2/run_1.2_trial
 description: |
     Truth catalog for Run 1.2. Static objects.
     No internal or MW extinction is applied.
-
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.2_variable_lightcurve.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.2_variable_lightcurve.yaml
@@ -9,4 +9,4 @@ table_obs_metadata: obs_metadata
 description: |
     Truth catalog for Run 1.2, light curve tables for variable objects.
 
-included_by_default: true
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run1.2_variable_summary.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run1.2_variable_summary.yaml
@@ -5,4 +5,4 @@ filename: /global/projecta/projectdirs/lsst/groups/SSim/DC2/Run1.2/run1p2_light_
 description: |
     Truth catalog for Run 1.2, summary table for variable objects.
 
-included_by_default: true
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/hsc-pdr1-xmm.yaml
+++ b/GCRCatalogs/catalog_configs/hsc-pdr1-xmm.yaml
@@ -2,5 +2,5 @@ subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/cscratch1/sd/desc/hsc
 description: XMM field of the HSC PDR1
 creators: ['Hyper Suprime-Cam (HSC) collaboration']
-included_by_default: true
 pixel_scale: 0.168
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/proto-dc2_v2.1.2_test.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v2.1.2_test.yaml
@@ -13,4 +13,3 @@ description: |
     For a description of the catalog and the methods, please see https://goo.gl/fXDQwP
     No check of MD5 sum in this version.
 
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/proto-dc2_v3.0_test.yaml
+++ b/GCRCatalogs/catalog_configs/proto-dc2_v3.0_test.yaml
@@ -12,4 +12,3 @@ description: |
     ProtoDC2 is a down-scaled version of the catalog to be generated for LSST-DESC DC2.
     For a description of the catalog and the methods, please see https://goo.gl/fXDQwP
 
-included_by_default: true

--- a/GCRCatalogs/catalog_configs/protoDC2.yaml
+++ b/GCRCatalogs/catalog_configs/protoDC2.yaml
@@ -1,2 +1,2 @@
 alias: proto-dc2_v5.0
-included_by_default: true
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/protoDC2_run1.2.yaml
+++ b/GCRCatalogs/catalog_configs/protoDC2_run1.2.yaml
@@ -1,2 +1,2 @@
-alias: dc2_object_run1.2p_v4
+alias: proto-dc2_v3.0_test
 include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/protoDC2_test.yaml
+++ b/GCRCatalogs/catalog_configs/protoDC2_test.yaml
@@ -1,2 +1,1 @@
 alias: proto-dc2_v5.0_test
-included_by_default: true

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -175,5 +175,5 @@ available_catalogs = get_available_configs(os.path.join(os.path.dirname(__file__
 _available_catalogs_default = {
     k: resolve_config_alias(v)
     for k, v in available_catalogs.items()
-    if v.get('included_by_default') or v.get('include_in_default_catalog_list')
+    if v.get('include_in_default_catalog_list')
 }

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -4,20 +4,10 @@ test_register.py
 import pytest
 import GCRCatalogs
 
-_default_catalogs_min_set = {
-    'protoDC2',
-    'buzzard',
-    'buzzard_test',
-    'buzzard_high-res',
-}
-
 # pylint: disable=redefined-outer-name
 @pytest.fixture(scope='module')
 def default_catalogs():
     return GCRCatalogs.get_available_catalogs()
-
-def test_default_catalog_set(default_catalogs):
-    assert set(default_catalogs).issuperset(_default_catalogs_min_set)
 
 def test_available_catalog_set(default_catalogs):
     assert set(GCRCatalogs.available_catalogs).issuperset(set(default_catalogs))


### PR DESCRIPTION
There is an option that can be specified in the catalog config to determine whether the catalog in consideration will show up when an user runs `GCRCatalogs.get_available_catalog()`, or only show up when the user runs `GCRCatalogs.get_available_catalog(include_default_only=False)`. 

The reason for this difference is that the number of catalogs is large, and most catalogs are not interesting for end users. 

This option was named `included_by_default`, but it is not clear to most people what this option means, so it was later renamed to `include_in_default_catalog_list`. However, it seems that people have not been using the new name. This PR makes this change once and for all. This PR also selects fewer "default catalogs". 