### PR TITLE
Refactor register module and add `based_on` option for catalog configs

### DIFF
--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -6,10 +6,16 @@ import requests
 from GCR import BaseGenericCatalog
 
 
-__all__ = ['available_catalogs', 'get_catalog_config', 'get_available_catalogs', 'load_catalog']
+__all__ = ['has_catalog', 'get_catalog_config', 'get_available_catalogs', 'load_catalog']
 
 _CONFIG_DIRNAME = 'catalog_configs'
 _GITHUB_URL = 'https://raw.githubusercontent.com/LSSTDESC/gcr-catalogs/master/GCRCatalogs'
+_YAML_EXTENSIONS = ('.yaml', '.yml')
+
+
+def load_yaml_local(yaml_file):
+    with open(yaml_file) as f:
+        return yaml.safe_load(f)
 
 
 def load_yaml(yaml_file):
@@ -19,8 +25,7 @@ def load_yaml(yaml_file):
     try:
         r = requests.get(yaml_file, stream=True)
     except (requests.exceptions.MissingSchema, requests.exceptions.URLRequired):
-        with open(yaml_file) as f:
-            config = yaml.safe_load(f)
+        config = load_yaml_local(yaml_file)
     else:
         if r.status_code == 404:
             raise requests.RequestException('404 Not Found!')
@@ -29,11 +34,133 @@ def load_yaml(yaml_file):
     return config
 
 
-def strip_yaml_extension(filename):
-    """
-    remove ending '.yaml' in *filename*
-    """
-    return filename[:-5] if filename.lower().endswith('.yaml') else filename
+class Config():
+    def __init__(self, config_path, config_dir=''):
+        self.path = os.path.join(config_dir, config_path)
+        self.basename = os.path.basename(self.path)
+        self.rootname, self.ext = os.path.splitext(self.basename)
+        self.name = self.rootname.lower()
+        self._content = None
+
+    @property
+    def ignore(self):
+        return (
+            self.rootname.startswith('_') or
+            self.ext.lower() not in _YAML_EXTENSIONS
+        )
+
+    @property
+    def content(self):
+        if self._content is None:
+            self._content = load_yaml_local(self.path)
+        return self._content
+
+
+class ConfigRegister():
+    def __init__(self, config_dir):
+        self._config_dir = config_dir
+        self._configs = dict()
+        self._configs_resolved = dict()
+
+        for config_file in os.listdir(self._config_dir):
+            config = Config(config_file, self._config_dir)
+            if not config.ignore:
+                self._configs[config.name] = config
+
+    @staticmethod
+    def normalize_name(name):
+        name = str(name).lower()
+        for extension in _YAML_EXTENSIONS:
+            if name.endswith(extension):
+                return name[:-len(extension)]
+        return name
+
+    def get_raw(self, name):
+        name = self.normalize_name(name)
+        if name not in self._configs:
+            raise KeyError('Catalog {} does not exist.'.format(name))
+        return self._configs[name].content
+
+    def resolve_config(self, config, past_refs=None):
+        for key in ('alias', 'based_on'):
+            if config.get(key):
+                base_name = self.normalize_name(config[key])
+                base_config = self.get_raw(base_name)
+
+                if past_refs is None:
+                    past_refs = [base_name]
+                elif base_name in past_refs:
+                    raise RecursionError('Recursive reference')
+                else:
+                    past_refs.append(base_name)
+
+                if key == 'based_on':
+                    config = config.copy()
+                    del config[key]
+                    base_config = base_config.copy()
+                    base_config.update(config)
+
+                return self.resolve_config(base_config, past_refs)
+
+        return config
+
+    def get_resolved(self, name):
+        name = self.normalize_name(name)
+        if name not in self._configs_resolved:
+            self._configs_resolved[name] = self.resolve_config(self.get_raw(name), [name])
+        config = self._configs_resolved[name]
+        if 'subclass_name' not in config:
+            raise ValueError('`subclass_name` is missing in the config of {}'
+                             'and its dependencies'.format(name))
+        return config
+
+    def online_alias_check(self, name):
+        config = self.get_raw(name)
+        if config.get('alias'):
+            name = self.normalize_name(name)
+            url = '/'.join((_GITHUB_URL, _CONFIG_DIRNAME, self._configs[name].basename))
+            try:
+                online_config = load_yaml(url)
+            except (requests.RequestException, yaml.error.YAMLError):
+                pass
+            else:
+                if config['alias'] != online_config.get('alias'):
+                    warnings.warn('`{}` is currently an alias of `{}`.'
+                    'Please be advised that it will soon change to point to an updated version `{}`.'
+                    'The updated version is already available in the master branch.'.format(
+                        name,
+                        config['alias'],
+                        online_config.get('alias'),
+                    ))
+
+    def __contains__(self, key):
+        return (self.normalize_name(key) in self._configs)
+
+    @property
+    def catalog_configs(self):
+        return {v.rootname: v.content for v in self._configs.values()}
+
+    @property
+    def default_catalog_configs(self):
+        return {
+            v.rootname: self.get_resolved(v.name) for v in self._configs.values()
+            if v.content.get('include_in_default_catalog_list')
+        }
+
+    @property
+    def catalog_list(self):
+        return sorted((v.rootname for v in self._configs.values()))
+
+    @property
+    def default_catalog_list(self):
+        return sorted((
+            v.rootname for v in self._configs.values()
+            if v.content.get('include_in_default_catalog_list')
+        ))
+
+    @property
+    def reader_list(self):
+        return sorted(set((self.get_resolved(k)['subclass_name'] for k in self._configs)))
 
 
 def import_subclass(subclass_path, package=None, required_base_class=None):
@@ -45,57 +172,9 @@ def import_subclass(subclass_path, package=None, required_base_class=None):
     if package and not module.startswith('.'):
         module = '.' + module
     subclass = getattr(importlib.import_module(module, package), subclass_name)
-    if required_base_class:
-        assert issubclass(subclass, required_base_class), "Provided class is not a subclass of *required_base_class*"
+    if required_base_class and not issubclass(subclass, required_base_class):
+        raise ValueError("Provided class is not a subclass of *required_base_class*")
     return subclass
-
-
-def get_available_configs(config_dir, register=None):
-    """
-    Return (or update) a dictionary *register* that contains all config files in *config_dir*.
-    """
-    if register is None:
-        register = dict()
-
-    for config_file in os.listdir(config_dir):
-        if config_file.startswith('_') or not config_file.lower().endswith('.yaml'):
-            continue
-
-        name = strip_yaml_extension(config_file)
-        config = load_yaml(os.path.join(config_dir, config_file))
-        register[name] = config
-
-    return register
-
-
-def resolve_config_alias(config_dict, last_alias=None):
-    """
-    resolve the alias in *config_dict* and return resolved config dict
-    """
-    if config_dict.get('alias'):
-        alias = strip_yaml_extension(config_dict.get('alias', ''))
-        if alias not in available_catalogs:
-            raise KeyError('Catalog {} does not exist in available catalogs.'.format(alias))
-        if last_alias and last_alias == alias:
-            raise ValueError('alias points to itself!')
-        return resolve_config_alias(available_catalogs[alias], alias)
-    return config_dict
-
-
-def get_catalog_config(catalog):
-    """
-    get the config dict of *catalog*
-    """
-    return resolve_config_alias(available_catalogs[catalog])
-
-
-def get_available_catalogs(include_default_only=True):
-    """
-    Return *available_catalogs* as a dictionary
-
-    If *include_default_only* is set to False, return all catalogs.
-    """
-    return _available_catalogs_default if include_default_only else available_catalogs
 
 
 def load_catalog_from_config_dict(catalog_config):
@@ -120,6 +199,48 @@ def load_catalog_from_config_dict(catalog_config):
                            BaseGenericCatalog)(**catalog_config)
 
 
+def get_available_catalogs(include_default_only=True, names_only=False):
+    """
+    Return available catalogs as a dictionary,
+    or a list (when *names_only* set to True).
+
+    If *include_default_only* is set to False, return all catalogs.
+    If *names_only* is set to False, return catalog name and associated configs
+    """
+    if names_only:
+        if include_default_only:
+            return _config_register.default_catalog_list
+        return _config_register.catalog_list
+
+    if include_default_only:
+        return _config_register.default_catalog_configs
+    return _config_register.catalog_configs
+
+
+def get_reader_list():
+    """
+    Returns a list of readers
+    """
+    return _config_register.reader_list
+
+
+def get_catalog_config(catalog_name, raw_config=False):
+    """
+    Returns the config dict of *catalog_name*.
+    If *raw_config* set to `True`, do not resolve references (alias, based_on)
+    """
+    if raw_config:
+        return _config_register.get_raw(catalog_name)
+    return _config_register.get_resolved(catalog_name)
+
+
+def has_catalog(catalog_name):
+    """
+    Check if *catalog_name* exists
+    """
+    return catalog_name in _config_register
+
+
 def load_catalog(catalog_name, config_overwrite=None):
     """
     Load a galaxy catalog as specified in one of the yaml file in catalog_configs.
@@ -135,45 +256,13 @@ def load_catalog(catalog_name, config_overwrite=None):
     ------
     galaxy_catalog : instance of a subclass of BaseGalaxyCatalog
     """
-    catalog_name = strip_yaml_extension(catalog_name)
-
-    if catalog_name not in available_catalogs:
-        raise KeyError("Catalog `{}` does not exist in the register. See `available_catalogs`.".format(catalog_name))
-
-    config = available_catalogs[catalog_name]
-
-    if config.get('alias'):
-        if strip_yaml_extension(config.get('alias', '')) == catalog_name:
-            raise ValueError('Oops, config {} alias itself!'.format(catalog_name))
-        url = '{}/{}/{}.yaml'.format(_GITHUB_URL, _CONFIG_DIRNAME, catalog_name)
-        try:
-            online_config = load_yaml(url)
-        except (requests.RequestException, yaml.error.YAMLError):
-            pass
-        else:
-            if config['alias'] != online_config.get('alias'):
-                warnings.warn('`{}` is currently an alias of `{}`.'
-                'Please be advised that it will soon change to point to an updated version `{}`.'
-                'The updated version is already available in the master branch.'.format(
-                    catalog_name,
-                    config['alias'],
-                    online_config.get('alias'),
-                ))
-
-        return load_catalog(config['alias'], config_overwrite)
-
+    _config_register.online_alias_check(catalog_name)
+    config = _config_register.get_resolved(catalog_name)
     if config_overwrite:
-        if 'alias' in config_overwrite:
-            raise ValueError('`config_overwrite` cannot specify `alias`!')
+        if any(key in config_overwrite for key in ('alias', 'based_on')):
+            raise ValueError('`config_overwrite` cannot specify `alias` or `based_on`!')
         config = config.copy()
         config.update(config_overwrite)
-
     return load_catalog_from_config_dict(config)
 
-
-available_catalogs = get_available_configs(os.path.join(os.path.dirname(__file__), _CONFIG_DIRNAME))
-_available_catalogs_default = {
-    k: resolve_config_alias(v)
-    for k, v in available_catalogs.items()
-    if v.get('include_in_default_catalog_list')
-}
+_config_register = ConfigRegister(os.path.join(os.path.dirname(__file__), _CONFIG_DIRNAME))

--- a/tests/test_reader_modules.py
+++ b/tests/test_reader_modules.py
@@ -4,10 +4,7 @@ test_reader_modules.py
 import pytest
 import GCRCatalogs
 
-all_readers = set((
-    GCRCatalogs.register.resolve_config_alias(v)['subclass_name']
-    for v in GCRCatalogs.available_catalogs.values()
-))
+all_readers = GCRCatalogs.register.get_reader_list()
 
 @pytest.mark.parametrize('reader', all_readers)
 def test_reader_module(reader):

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -10,16 +10,16 @@ def default_catalogs():
     return GCRCatalogs.get_available_catalogs()
 
 def test_available_catalog_set(default_catalogs):
-    assert set(GCRCatalogs.available_catalogs).issuperset(set(default_catalogs))
+    all_catalogs = GCRCatalogs.get_available_catalogs(False, True)
+    assert set(all_catalogs).issuperset(set(default_catalogs))
 
-@pytest.mark.parametrize('catalog', list(GCRCatalogs.get_available_catalogs()))
+@pytest.mark.parametrize('catalog', GCRCatalogs.get_available_catalogs(names_only=True))
 def test_default_catalog_config(catalog, default_catalogs):
     c = GCRCatalogs.get_catalog_config(catalog)
     v = default_catalogs[catalog]
     assert set(c) == set(v)
     assert c['subclass_name'] == v['subclass_name']
 
-@pytest.mark.parametrize('catalog', list(GCRCatalogs.available_catalogs))
-def test_config_entries(catalog):
-    c = GCRCatalogs.get_catalog_config(catalog)
-    assert 'subclass_name' in c
+@pytest.mark.parametrize('catalog', GCRCatalogs.get_available_catalogs(False, names_only=True))
+def test_has_catalog(catalog):
+    assert GCRCatalogs.has_catalog(catalog)


### PR DESCRIPTION
This PR refactors `register` module by introducing the `ConfigRegister` class, to make things a bit more readable and easier to maintain, and also to reduce the load time of `GCRCatalogs`.

Also, a new `based_on` option is introduced with this refactoring, to allow users creating catalog configs that are based on other catalog configs, but with slight updated options. There has been the `alias` option that allows users creating catalog aliases, but in many cases a user may want to create a config that is almost identical to another one, but with some small adjustments to some options. 

With this feature, the yaml file of `dc2_object_run1.1p_tract4850`, for example, can now be written as:
```yaml
based_on: dc2_object_run1.1p
filename_pattern: '(?:merged|object)_tract_4850\.hdf5$'
```
which would mean: "use `dc2_object_run1.1p` but also using other options here to update the original yaml". This can reduce duplications among catalog config files.

This PR by itself does not include changes to existing catalog configs. 