### PR TITLE
Issues/330 - Adds Run 2.1i dr1b catalog.

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1.yaml
@@ -1,0 +1,1 @@
+alias: dc2_object_run2.1i_dr1b

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1_tract4850.yaml
@@ -1,0 +1,1 @@
+alias: dc2_object_run2.1i_dr1b_tract4850.yaml

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a.yaml
@@ -5,4 +5,3 @@ filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 2.1i Object Catalog (with only DPDD columns and native columns needed for the DPDD columns)
 creators: ['DESC DC2 Team']
 pixel_scale: 0.2
-include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_tract4850.yaml
@@ -5,4 +5,3 @@ filename_pattern: 'trim_object_tract_4850\.hdf5$'
 description: DC2 Run 2.1i Object Catalog Tract 4850 (with only DPDD columns and native columns needed for the DPDD columns)
 creators: ['DESC DC2 Team']
 pixel_scale: 0.2
-include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_tract4850.yaml
@@ -1,0 +1,8 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1i/dpdd/calexp-v1:coadd-v1/object_table_summary
+schema_filename: trim_schema.yaml
+filename_pattern: 'trim_object_tract_4850\.hdf5$'
+description: DC2 Run 2.1i Object Catalog Tract 4850 (with only DPDD columns and native columns needed for the DPDD columns)
+creators: ['DESC DC2 Team']
+pixel_scale: 0.2
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b.yaml
@@ -1,0 +1,8 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run2.1i/w_2019_19-v1/dpdd/calexp-v1:coadd-dr1b-v1/object_table_summary
+schema_filename: trim_schema.yaml
+filename_pattern: 'trim_object_tract_\d+\.hdf5$'
+description: DC2 Run 2.1i Object Catalog (with only DPDD columns and native columns needed for the DPDD columns)
+creators: ['DESC DC2 Team']
+pixel_scale: 0.2
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b.yaml
@@ -1,5 +1,5 @@
 subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run2.1i/w_2019_19-v1/dpdd/calexp-v1:coadd-dr1b-v1/object_table_summary
+base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1i/dpdd/calexp-v1:coadd-dr1b-v1/object_table_summary
 schema_filename: trim_schema.yaml
 filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 2.1i Object Catalog (with only DPDD columns and native columns needed for the DPDD columns)

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns.yaml
@@ -1,5 +1,5 @@
 subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run2.1i/w_2019_19-v1/dpdd/calexp-v1:coadd-dr1b-v1/object_table_summary
+base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1i/dpdd/calexp-v1:coadd-dr1b-v1/object_table_summary
 schema_filename: schema.yaml
 filename_pattern: 'object_tract_\d+\.hdf5$'
 description: DC2 Run 2.1i Object Catalog (with only DPDD columns and native columns needed for the DPDD columns)

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns.yaml
@@ -5,4 +5,3 @@ filename_pattern: 'object_tract_\d+\.hdf5$'
 description: DC2 Run 2.1i Object Catalog (with only DPDD columns and native columns needed for the DPDD columns)
 creators: ['DESC DC2 Team']
 pixel_scale: 0.2
-include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns.yaml
@@ -1,6 +1,6 @@
 subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run2.1i/w_2019_19-v1/dpdd/calexp-v1:coadd-dr1b-v1/object_table_summary
-schema_filename: trim_schema.yaml
+schema_filename: schema.yaml
 filename_pattern: 'object_tract_\d+\.hdf5$'
 description: DC2 Run 2.1i Object Catalog (with only DPDD columns and native columns needed for the DPDD columns)
 creators: ['DESC DC2 Team']

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns.yaml
@@ -1,0 +1,8 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run2.1i/w_2019_19-v1/dpdd/calexp-v1:coadd-dr1b-v1/object_table_summary
+schema_filename: trim_schema.yaml
+filename_pattern: 'object_tract_\d+\.hdf5$'
+description: DC2 Run 2.1i Object Catalog (with only DPDD columns and native columns needed for the DPDD columns)
+creators: ['DESC DC2 Team']
+pixel_scale: 0.2
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_tract4850.yaml
@@ -1,0 +1,8 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run2.1i/w_2019_19-v1/dpdd/calexp-v1:coadd-dr1b-v1/object_table_summary
+schema_filename: trim_schema.yaml
+filename_pattern: 'trim_object_tract_4850\.hdf5$'
+description: DC2 Run 2.1i Object Catalog Tract 4850 (with only DPDD columns and native columns needed for the DPDD columns)
+creators: ['DESC DC2 Team']
+pixel_scale: 0.2
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_tract4850.yaml
@@ -1,5 +1,5 @@
 subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: /global/projecta/projectdirs/lsst/global/in2p3/Run2.1i/w_2019_19-v1/dpdd/calexp-v1:coadd-dr1b-v1/object_table_summary
+base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1i/dpdd/calexp-v1:coadd-dr1b-v1/object_table_summary
 schema_filename: trim_schema.yaml
 filename_pattern: 'trim_object_tract_4850\.hdf5$'
 description: DC2 Run 2.1i Object Catalog Tract 4850 (with only DPDD columns and native columns needed for the DPDD columns)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Confluence page (*DESC member only*).
 
 -  **DC2 "Object Catalogs"** \
    *by LSST DESC, compiled by Michael Wood-Vasey*
-   - `dc2_object_run2.1i_dr1a`: static object catalog for Run 2.1i DR1a (with only DPDD columns and native columns needed for the DPDD columns; use `dc2_object_run2.1i_dr1a_all_columns` if you need additional columns)
+   - `dc2_object_run2.1i_dr1`: static object catalog for Run 2.1i dr1 (with only DPDD columns and native columns needed for the DPDD columns; use `dc2_object_run2.1i_dr1_all_columns` if you need additional columns)
+   - `dc2_object_run2.1i_dr1_tract4850`: same as `dc2_object_run2.1i_dr1` but only has one tract (4850) for testing purpose / faster access
    - `dc2_object_run1.2i`: static object catalog for Run 1.2i (with only DPDD columns and native columns needed for the DPDD columns)
    - `dc2_object_run1.2i_with_photoz`: same as `dc2_object_run1.2i` but with photo-z's (columns that start with `photoz_`). Photo-z provided by Sam Schmidt.
    - `dc2_object_run1.2i_all_columns`: static object catalog for Run 1.2i (with DPDD and all native columns, slower to access)


### PR DESCRIPTION
Adds
I created and ran the `trim_tract_cat.py` to generate the trimmed files.
See new Notebook `validate_dc2_run2.1i_object_table.ipynb` in `DC2-analysis` branch `issues/95` for a quick tour of the Object Table.

https://github.com/LSSTDESC/DC2-analysis/blob/issues/95/validation/validate_dc2_run2.1i_object_table.ipynb

[edited by @yymao: fix #330]