### PR TITLE
Add hack to replace 'obshistid' with 'obs_meta.obshistid' in SQL query.

### DIFF
--- a/GCRCatalogs/dc2_truth.py
+++ b/GCRCatalogs/dc2_truth.py
@@ -274,9 +274,15 @@ class DC2TruthCatalogLightCurveReader(BaseGenericCatalog):
 
         for id_this in ids_needed:
             def dc2_truth_light_curve_native_quantity_getter(quantities):
+                # When 'obshistid' is needed, change it to 'obs_meta.obshistid' 
+                # so that the SQL query would work
+                quantities_str = ', '.join((
+                    (self._tables['obs_meta'] + '.obshistid') if q == 'obshistid' 
+                    else q for q in quantities
+                ))
                 dtype = np.dtype([(q, self._dtypes['light_curves'][q]) for q in quantities])
                 query = 'SELECT {0} FROM {1} JOIN {2} ON {1}.{4}={5} AND {1}.{3}={2}.{3};'.format(
-                    ', '.join(quantities),
+                    quantities_str,
                     self._tables['light_curves'],
                     self._tables['obs_meta'],
                     'obshistid',


### PR DESCRIPTION
The "quantity" is "obshistid", but when we run the SQL query join
we will want to refer to it as "obs_meta.obshistid" to disambiguate.

This PR introduces a specific hack for "obshistid".  It's not pretty, but it's not terrible, and I think it's worth adding to make progress.  A fuller fix should come when we fundamentally re-do the sqlite3 access for disk access reasons.

fix #337