### PR TITLE
photo-z catalog reader (for Run 2.1i DR1b)

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns_with_photoz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns_with_photoz.yaml
@@ -1,0 +1,8 @@
+subclass_name: composite.CompositeReader
+description: DC2 Run 2.1i DR1b Object Catalog (all columns) with photo-z
+catalogs:
+  - catalog_name: dc2_object_run2.1i_dr1b_all_columns
+    matching_method: MATCHING_FORMAT
+  - subclass_name: photoz.PhotoZCatalog2
+    base_dir: '/global/projecta/projectdirs/lsst/groups/PZ/PhotoZDC2/run2.1i_all_patches/outputs'
+    matching_method: MATCHING_FORMAT

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_tract4850_with_photoz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_tract4850_with_photoz.yaml
@@ -1,0 +1,10 @@
+subclass_name: composite.CompositeReader
+description: DC2 Run 2.1i DR1b Object Catalog with photo-z (tract 4850 only)
+catalogs:
+  - catalog_name: dc2_object_run2.1i_dr1b
+    filename_pattern: 'trim_object_tract_4850\.hdf5$'
+    matching_method: MATCHING_FORMAT
+  - subclass_name: photoz.PhotoZCatalog2
+    base_dir: '/global/projecta/projectdirs/lsst/groups/PZ/PhotoZDC2/run2.1i_all_patches/outputs'
+    tract_glob_pattern: '4850'
+    matching_method: MATCHING_FORMAT

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_with_photoz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_with_photoz.yaml
@@ -1,0 +1,8 @@
+subclass_name: composite.CompositeReader
+description: DC2 Run 2.1i DR1b Object Catalog with photo-z
+catalogs:
+  - catalog_name: dc2_object_run2.1i_dr1b
+    matching_method: MATCHING_FORMAT
+  - subclass_name: photoz.PhotoZCatalog2
+    base_dir: '/global/projecta/projectdirs/lsst/groups/PZ/PhotoZDC2/run2.1i_all_patches/outputs'
+    matching_method: MATCHING_FORMAT

--- a/GCRCatalogs/photoz.py
+++ b/GCRCatalogs/photoz.py
@@ -152,6 +152,7 @@ class PhotoZFileObject():
     """
     HDF5 file wrapper for PhotoZCatalog2
     """
+    _KEY_PDF_BINS = 'pdf/zgrid'
     def __init__(self, path, filename_pattern=None):
 
         if isinstance(filename_pattern, re.Pattern): # pylint: disable=no-member
@@ -178,7 +179,7 @@ class PhotoZFileObject():
         if self._keys is None:
             collector = set()
             def collect(name, obj):
-                if isinstance(obj, h5py.Dataset) and name != 'pdf/zgrid':
+                if isinstance(obj, h5py.Dataset) and name != self._KEY_PDF_BINS:
                     collector.add(name)
             self.handle.visititems(collect)
             self._keys = tuple(collector)
@@ -186,7 +187,7 @@ class PhotoZFileObject():
 
     def __len__(self):
         if self._len is None:
-            self._len = len(self['id/galaxy_id'])
+            self._len = self.handle[first(self.keys())].shape[0]
         return self._len
 
     def __getitem__(self, key):
@@ -214,7 +215,7 @@ class PhotoZFileObject():
 
     @property
     def pdf_bins(self):
-        return self['pdf/zgrid']
+        return self[self._KEY_PDF_BINS]
 
 
 class PhotoZCatalog2(BaseGenericCatalog):

--- a/GCRCatalogs/photoz.py
+++ b/GCRCatalogs/photoz.py
@@ -227,7 +227,7 @@ class PhotoZCatalog2(BaseGenericCatalog):
         self._datasets = self._generate_datasets()
 
         self._quantity_modifiers = {
-            'galaxy_id': 'id/galaxy_id',
+            'id': 'id/galaxy_id',
             'photoz_pdf': 'pdf/pdf',
             'photoz_mode': 'point_estimates/z_mode',
             'photoz_mean': 'point_estimates/z_mean',

--- a/GCRCatalogs/photoz.py
+++ b/GCRCatalogs/photoz.py
@@ -270,6 +270,7 @@ class PhotoZCatalog2(BaseGenericCatalog):
             if native_filters and not native_filters.check_scalar(tract_patch):
                 continue
             yield dataset.get
+            dataset.close() # to avoid OS complaining too many open files
 
     def close_all_file_handles(self):
         """Clear all cached file handles"""

--- a/GCRCatalogs/photoz.py
+++ b/GCRCatalogs/photoz.py
@@ -1,41 +1,48 @@
 """
 Photo-z catalog reader
 
-This reader was designed by Yao-Yuan Mao,
+The PhotoZCatalog reader was designed by Yao-Yuan Mao,
 based a photo-z catalog provided by Sam Schmidt, in Feb 2019.
+
+The PhotoZCatalog2 reader, which uses PhotoZFileObject, was designed by Yao-Yuan Mao,
+based a photo-z catalog provided by Sam Schmidt, in Jul 2019.
 """
 
 import re
 import os
 import warnings
 import shutil
+import glob
 
 import yaml
 import numpy as np
 import pandas as pd
-
+import h5py
 from GCR import BaseGenericCatalog
 
-__all__ = ['PhotoZCatalog']
+from .utils import first
 
-FILE_PATTERN = r'run\d\.\d+[a-z]+_PZ_tract_\d+\.h5$'
-METADATA_FILENAME = 'metadata.yaml'
-PDF_BIN_INFO = {
-    'start': 0.005,
-    'stop': 1.01,
-    'step': 0.01,
-    'decimals_to_round': 3,
-}
+__all__ = ['PhotoZCatalog', 'PhotoZCatalog2']
+
 
 class PhotoZCatalog(BaseGenericCatalog):
 
+    _FILE_PATTERN = r'run\d\.\d+[a-z]+_PZ_tract_\d+\.h5$'
+    _METADATA_FILENAME = 'metadata.yaml'
+    _PDF_BIN_INFO = {
+        'start': 0.005,
+        'stop': 1.01,
+        'step': 0.01,
+        'decimals_to_round': 3,
+    }
+
     def _subclass_init(self, **kwargs):
         self.base_dir = kwargs['base_dir']
-        self._filename_re = re.compile(kwargs.get('filename_pattern', FILE_PATTERN))
-        _metadata_filename = kwargs.get('metadata_filename', METADATA_FILENAME)
+        self._filename_re = re.compile(kwargs.get('filename_pattern', self._FILE_PATTERN))
+        _metadata_filename = kwargs.get('metadata_filename', self._METADATA_FILENAME)
         self._metadata_path = os.path.join(self.base_dir, _metadata_filename)
 
-        self._pdf_bin_info = kwargs.get('pdf_bin_info', PDF_BIN_INFO)
+        self._pdf_bin_info = kwargs.get('pdf_bin_info', self._PDF_BIN_INFO)
         self._pdf_bin_centers = np.round(np.arange(
             self._pdf_bin_info['start'],
             self._pdf_bin_info['stop'],
@@ -139,3 +146,127 @@ class PhotoZCatalog(BaseGenericCatalog):
         See also: list_all_native_quantities
         """
         return super(PhotoZCatalog, self).list_all_quantities(with_info=with_info)
+
+
+class PhotoZFileObject():
+    """
+    HDF5 file wrapper for PhotoZCatalog2
+    """
+    def __init__(self, path, filename_pattern=None):
+
+        filename_re = filename_pattern if isinstance(filename_pattern, re.Pattern) else re.compile(filename_pattern)
+        basename = os.path.basename(path)
+        match = filename_re.match(basename)
+        if match is None:
+            raise ValueError('filename {} does not match required pattern')
+
+        tract, patch_x, patch_y, index = match.groups()
+
+        self.path = path
+        self.tract = int(tract)
+        self.patch = '{},{}'.format(patch_x, patch_y)
+        self.index = int(index)
+        self._handle = None
+        self._keys = None
+        self._len = None
+
+    def keys(self):
+        if self._keys is None:
+            collector = set()
+            def collect(name, obj):
+                if isinstance(obj, h5py.Dataset) and name != 'pdf/zgrid':
+                    collector.add(name)
+            self.handle.visititems(collect)
+            self._keys = tuple(collector)
+        return list(self._keys) + ['tract', 'patch']
+
+    def __len__(self):
+        if self._len is None:
+            self._len = len(self['id/galaxy_id'])
+        return self._len
+
+    def __getitem__(self, key):
+        if key == 'tract':
+            return np.repeat(self.tract, len(self))
+        if key == 'patch':
+            return np.repeat(self.patch, len(self))
+        return self.handle[key][()]
+
+    get = __getitem__
+
+    @property
+    def handle(self):
+        if self._handle is None:
+            self._handle = h5py.File(self.path, mode='r')
+        return self._handle
+
+    def open(self):
+        return self.handle
+
+    def close(self):
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+
+    @property
+    def pdf_bins(self):
+        return self['pdf/zgrid']
+
+
+class PhotoZCatalog2(BaseGenericCatalog):
+
+    _FILE_RE_PATTERN = r'photoz_pdf_Run\d\.[0-9a-z]+_tract_(\d{4})_patch_(\d)_(\d)_idx_(\d+).hdf5'
+    _FILE_GLOB_PATTERN = 'photoz_*.hdf5'
+    _TRACT_GLOB_PATTERN = '*'
+
+    def _subclass_init(self, **kwargs):
+        self.base_dir = kwargs['base_dir']
+        self._filename_re = re.compile(kwargs.get('filename_pattern', self._FILE_RE_PATTERN))
+        self._file_glob_pattern = kwargs.get('filename_glob_pattern', self._FILE_GLOB_PATTERN)
+        self._tract_glob_pattern = kwargs.get('tract_glob_pattern', self._TRACT_GLOB_PATTERN)
+        self._datasets = self._generate_datasets()
+
+        self._quantity_modifiers = {
+            'galaxy_id': 'id/galaxy_id',
+            'photoz_pdf': 'pdf/pdf',
+            'photoz_mode': 'point_estimates/z_mode',
+            'photoz_mean': 'point_estimates/z_mean',
+            'photoz_median': 'point_estimates/z_median',
+            'photoz_mode_ml': 'point_estimates/z_mode_ml',
+            'photoz_mode_ml_red_chi2': 'point_estimates/z_mode_ml_red_chi2',
+            'photoz_odds': 'point_estimates/ODDS',
+        }
+
+        self._native_filter_quantities = {'tract', 'patch'}
+
+    def _generate_native_quantity_list(self):
+        return first(self._datasets).keys()
+
+    def _generate_datasets(self):
+        datasets = list()
+        for path in glob.glob(os.path.join(self.base_dir, self._tract_glob_pattern, self._file_glob_pattern)):
+            try:
+                dataset = PhotoZFileObject(path, self._filename_re)
+            except ValueError:
+                continue
+            datasets.append(dataset)
+        return sorted(datasets, key=(lambda d: d.index))
+
+    @property
+    def photoz_pdf_bin_centers(self):
+        """
+        expose self._pdf_bin_centers as a public property.
+        """
+        return first(self._datasets).pdf_bins
+
+    def _iter_native_dataset(self, native_filters=None):
+        for dataset in self._datasets:
+            tract_patch = {'tract': dataset.tract, 'patch': dataset.patch}
+            if native_filters and not native_filters.check_scalar(tract_patch):
+                continue
+            yield dataset.get
+
+    def close_all_file_handles(self):
+        """Clear all cached file handles"""
+        for dataset in self._datasets:
+            dataset.close()

--- a/GCRCatalogs/photoz.py
+++ b/GCRCatalogs/photoz.py
@@ -154,7 +154,11 @@ class PhotoZFileObject():
     """
     def __init__(self, path, filename_pattern=None):
 
-        filename_re = filename_pattern if isinstance(filename_pattern, re.Pattern) else re.compile(filename_pattern)
+        if isinstance(filename_pattern, re.Pattern): # pylint: disable=no-member
+            filename_re = filename_pattern
+        else:
+            filename_re = re.compile(filename_pattern)
+
         basename = os.path.basename(path)
         match = filename_re.match(basename)
         if match is None:


### PR DESCRIPTION
This PR adds (yet another) photo-z catalog reader. The photo-z catalog is provided by @sschmidt23 for the objects in object catalog Run 2.1i DR1b. 

I've done some limited tests on this reader and it works as expected. I say "limited" because there are some photo-z catalog files that seem corrupted and the reader is not able to load those files. I've asked @sschmidt23 to look into it.

For a working example, try:
```python
cat = GCRCatalogs.load_catalog('dc2_object_run2.1i_dr1b_tract4850_with_photoz')
```
