### PR TITLE
h5py `Dataset.value` property deprecated

### DIFF
--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -107,29 +107,28 @@ class AlphaQGalaxyCatalog(BaseGenericCatalog):
         self.lightcone = kwargs.get('lightcone')
 
         with h5py.File(self._file, 'r') as fh:
-            # pylint: disable=no-member
             # get version
             catalog_version = list()
             for version_label in ('Major', 'Minor', 'MinorMinor'):
                 try:
-                    catalog_version.append(fh['/metaData/version' + version_label].value)
+                    catalog_version.append(fh['/metaData/version' + version_label][()])
                 except KeyError:
                     break
             catalog_version = StrictVersion('.'.join(map(str, catalog_version or (2, 0))))
 
             # get cosmology
             self.cosmology = FlatLambdaCDM(
-                H0=fh['metaData/simulationParameters/H_0'].value,
-                Om0=fh['metaData/simulationParameters/Omega_matter'].value,
-                Ob0=fh['metaData/simulationParameters/Omega_b'].value,
+                H0=fh['metaData/simulationParameters/H_0'][()],
+                Om0=fh['metaData/simulationParameters/Omega_matter'][()],
+                Ob0=fh['metaData/simulationParameters/Omega_b'][()],
             )
-            self.cosmology.sigma8 = fh['metaData/simulationParameters/sigma_8'].value
-            self.cosmology.n_s = fh['metaData/simulationParameters/N_s'].value
-            self.halo_mass_def = fh['metaData/simulationParameters/haloMassDefinition'].value
+            self.cosmology.sigma8 = fh['metaData/simulationParameters/sigma_8'][()]
+            self.cosmology.n_s = fh['metaData/simulationParameters/N_s'][()]
+            self.halo_mass_def = fh['metaData/simulationParameters/haloMassDefinition'][()]
 
             # get sky area
             if catalog_version >= StrictVersion("2.1.1"):
-                self.sky_area = float(fh['metaData/skyArea'].value)
+                self.sky_area = float(fh['metaData/skyArea'][()])
             else:
                 self.sky_area = 25.0 #If the sky area isn't specified use the default value of the sky area.
 
@@ -353,7 +352,7 @@ class AlphaQGalaxyCatalog(BaseGenericCatalog):
             raise ValueError('*native_filters* is not supported')
         with h5py.File(self._file, 'r') as fh:
             def _native_quantity_getter(native_quantity):
-                return fh['galaxyProperties/{}'.format(native_quantity)].value # pylint: disable=no-member
+                return fh['galaxyProperties/{}'.format(native_quantity)][()]
             yield _native_quantity_getter
 
 

--- a/GCRCatalogs/alphaq_addon.py
+++ b/GCRCatalogs/alphaq_addon.py
@@ -38,7 +38,7 @@ class AlphaQAddonCatalog(BaseGenericCatalog):
         assert not native_filters, '*native_filters* is not supported'
         with h5py.File(self._addon_filename, 'r') as fh_addon:
             def native_quantity_getter(native_quantity):
-                return fh_addon['{}/{}'.format(self._addon_group,native_quantity)].value # pylint: disable=E1101
+                return fh_addon['{}/{}'.format(self._addon_group,native_quantity)][()]
             yield native_quantity_getter
 
 
@@ -62,7 +62,7 @@ class AlphaQTidalCatalog(BaseGenericCatalog):
     def _generate_native_quantity_list(self):
         native_quantities = set()
         with h5py.File(self._filename, 'r') as fh:
-            data = fh['tidal'].value # pylint: disable=E1101
+            data = fh['tidal'][()]
             for name, (dt, _) in data.dtype.fields.items():
                 native_quantities.add(name)
                 if dt.shape:
@@ -72,7 +72,7 @@ class AlphaQTidalCatalog(BaseGenericCatalog):
 
     def _iter_native_dataset(self, native_filters=None):
         with h5py.File(self._filename, 'r') as fh:
-            data = fh['tidal'].value # pylint: disable=E1101
+            data = fh['tidal'][()]
             def native_quantity_getter(native_quantity):
                 if '/' not in native_quantity:
                     return data[native_quantity]

--- a/GCRCatalogs/alphaq_addon.py
+++ b/GCRCatalogs/alphaq_addon.py
@@ -27,7 +27,7 @@ class AlphaQAddonCatalog(BaseGenericCatalog):
             #get all the names of objects in this tree
             hgroup.visit(hobjects.append)
             #filter out the group objects and keep the dataste objects
-            hdatasets = [hobject for hobject in hobjects if type(hgroup[hobject]) == h5py.Dataset]
+            hdatasets = [hobject for hobject in hobjects if isinstance(hgroup[hobject], h5py.Dataset)]
             addon_native_quantities = set(hdatasets)
         return addon_native_quantities
 

--- a/GCRCatalogs/cosmodc2.py
+++ b/GCRCatalogs/cosmodc2.py
@@ -240,11 +240,10 @@ class CosmoDC2ParentClass(BaseGenericCatalog):
         return native_quantities
 
     def _check_version(self, fh, file_name):
-        # pylint: disable=E1101
         catalog_version = list()
         for version_label in ('Major', 'Minor', 'MinorMinor'):
             try:
-                catalog_version.append(fh['/metaData/version' + version_label].value)
+                catalog_version.append(fh['/metaData/version' + version_label][()])
             except KeyError:
                 break
         catalog_version = StrictVersion('.'.join(map(str, catalog_version or (0, 0))))
@@ -253,10 +252,9 @@ class CosmoDC2ParentClass(BaseGenericCatalog):
             raise ValueError('Catalog version {} does not match config version {} for healpix file {}'.format(catalog_version, config_version, file_name))
 
     def _check_cosmology(self, fh, file_name, atol):
-        # pylint: disable=E1101
         for name_hdf5, name_astropy in (('H_0', 'h'), ('Omega_matter', 'Om0'), ('Omega_b', 'Ob0')):
             try:
-                value_catalog = fh['metaData/{}'.format(name_hdf5)].value
+                value_catalog = fh['metaData/{}'.format(name_hdf5)][()]
             except KeyError:
                 warnings.warn('missing cosmology {} in metadata for healpix file {}'.format(name_hdf5, file_name))
                 continue
@@ -305,7 +303,7 @@ class CosmoDC2ParentClass(BaseGenericCatalog):
 
                 if self.lightcone: # get sky area
                     try:
-                        sky_area_this = fh['metaData/skyArea'].value # pylint: disable=E1101
+                        sky_area_this = fh['metaData/skyArea'][()]
                     except KeyError:
                         sky_area_this = default_sky_area
                     sky_area_this = float(sky_area_this)
@@ -316,7 +314,7 @@ class CosmoDC2ParentClass(BaseGenericCatalog):
                 else: # get other meta info (box size and redshift)
                     for key in ('box_size', 'redshift'):
                         try:
-                            value_this = fh['metaData/'+key].value # pylint: disable=E1101
+                            value_this = fh['metaData/'+key][()]
                         except KeyError:
                             pass
                         else:
@@ -357,9 +355,9 @@ class CosmoDC2ParentClass(BaseGenericCatalog):
                 continue
             with h5py.File(file_path, 'r') as fh:
                 for group in self._get_group_names(fh):
-                    # pylint: disable=E1101,W0640
+                    # pylint: disable=W0640
                     if len(fh[group]):
-                        yield lambda native_quantity: fh['{}/{}'.format(group, native_quantity)].value
+                        yield lambda native_quantity: fh['{}/{}'.format(group, native_quantity)][()]
 
     def _get_quantity_info_dict(self, quantity, default=None):
         q_mod = self.get_quantity_modifier(quantity)

--- a/GCRCatalogs/dc2_truth.py
+++ b/GCRCatalogs/dc2_truth.py
@@ -64,7 +64,7 @@ class DC2TruthLCSummaryReader(BaseGenericCatalog):
                           "for this catalog; just use filters.")
         with h5py.File(self._file_name, 'r') as file_handle:
             def _native_qty_getter(qty_name):
-                return file_handle[qty_name].value
+                return file_handle[qty_name][()]
             yield _native_qty_getter
 
     def get_quantities(self, quantities, filters=None, native_filters=None, return_iterator=False):
@@ -274,10 +274,10 @@ class DC2TruthCatalogLightCurveReader(BaseGenericCatalog):
 
         for id_this in ids_needed:
             def dc2_truth_light_curve_native_quantity_getter(quantities):
-                # When 'obshistid' is needed, change it to 'obs_meta.obshistid' 
+                # When 'obshistid' is needed, change it to 'obs_meta.obshistid'
                 # so that the SQL query would work
                 quantities_str = ', '.join((
-                    (self._tables['obs_meta'] + '.obshistid') if q == 'obshistid' 
+                    (self._tables['obs_meta'] + '.obshistid') if q == 'obshistid'
                     else q for q in quantities
                 ))
                 dtype = np.dtype([(q, self._dtypes['light_curves'][q]) for q in quantities])


### PR DESCRIPTION
`h5py` in DESC python environments has been updated and the use of `Dataset.value` property is now deprecated ([ref](http://docs.h5py.org/en/stable/whatsnew/2.1.html#dataset-value-property-is-now-deprecated)).

This PR replaces all the occurrence of `Dataset.value` with `Dataset[()]` as recommended. Several pylint "no member" exceptions can be removed as well. 