### PR TITLE
Implement faster `__len__` method for DC2 object, DM, and composite catalogs

### DIFF
--- a/GCRCatalogs/composite.py
+++ b/GCRCatalogs/composite.py
@@ -25,8 +25,10 @@ class CompositeReader(CompositeCatalog):
             method = catalog_dict.get('matching_method', 'MATCHING_FORMAT')
             if method == 'MATCHING_FORMAT':
                 method = MATCHING_FORMAT
+                self.__len__ = instances[0].__len__
             elif method == 'MATCHING_ORDER':
                 method = MATCHING_ORDER
+                self.__len__ = instances[0].__len__
             methods.append(method)
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', 'CompositeCatalog is still an experimental feature')

--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -141,6 +141,7 @@ class DC2DMCatalog(BaseGenericCatalog):
 
         self._quantity_info_dict = self._generate_info_dict(self.META_PATH)
         self._native_filter_quantities = self._generate_native_quantity_list()
+        self._len = None
 
     def __del__(self):
         self.close_all_file_handles()
@@ -341,3 +342,8 @@ class DC2DMCatalog(BaseGenericCatalog):
                 yield native_quantity_getter
                 if not self.use_cache:
                     dataset.clear_cache()
+
+    def __len__(self):
+        if self._len is None:
+            self._len = sum(len(dataset) for dataset in self._datasets)
+        return self._len

--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -345,5 +345,5 @@ class DC2DMCatalog(BaseGenericCatalog):
 
     def __len__(self):
         if self._len is None:
-            self._len = sum(len(dataset) for dataset in self._datasets)
+            self._len = sum(dataset.scan_contents() for dataset in self._datasets)
         return self._len

--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -345,5 +345,6 @@ class DC2DMCatalog(BaseGenericCatalog):
 
     def __len__(self):
         if self._len is None:
+            # pylint: disable=attribute-defined-outside-init
             self._len = sum(dataset.scan_contents() for dataset in self._datasets)
         return self._len

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -626,5 +626,6 @@ class DC2ObjectCatalog(BaseGenericCatalog):
 
     def __len__(self):
         if self._len is None:
+            # pylint: disable=attribute-defined-outside-init
             self._len = sum(len(dataset) for dataset in self._datasets)
         return self._len

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -287,6 +287,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
                     self.pixel_scale, bands, has_modelfit_mag, dm_schema_version)
 
         self._quantity_info_dict = self._generate_info_dict(META_PATH, bands)
+        self._len = None
 
     def __del__(self):
         self.close_all_file_handles()
@@ -622,3 +623,8 @@ class DC2ObjectCatalog(BaseGenericCatalog):
                 yield dataset.get
                 if not self.use_cache:
                     dataset.clear_cache()
+
+    def __len__(self):
+        if self._len is None:
+            self._len = sum(len(dataset) for dataset in self._datasets)
+        return self._len


### PR DESCRIPTION
This PR implements faster `__len__` method for DC2 object and DM catalogs by reading the metadata. In addition, for composite catalogs, the `__len__` method is now set to the `__len__` method of the main catalog if the format is matched. This prevents the fallback to the slow `__len__` method that was implemented in the base class.

Fixes #348 