### PR TITLE
Use DR1b parquet format as the default for DR1 object catalog

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1.yaml
@@ -1,1 +1,1 @@
-alias: dc2_object_run2.1i_dr1b
+alias: dc2_object_run2.1i_dr1b_parquet

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1.yaml
@@ -1,1 +1,2 @@
 alias: dc2_object_run2.1i_dr1b_parquet
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1_tract4850.yaml
@@ -1,1 +1,1 @@
-alias: dc2_object_run2.1i_dr1b_tract4850.yaml
+alias: dc2_object_run2.1i_dr1b_tract4850_parquet

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b.yaml
@@ -5,4 +5,3 @@ filename_pattern: 'trim_object_tract_\d+\.hdf5$'
 description: DC2 Run 2.1i Object Catalog (with only DPDD columns and native columns needed for the DPDD columns)
 creators: ['DESC DC2 Team']
 pixel_scale: 0.2
-include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_all_columns.yaml
@@ -2,6 +2,6 @@ subclass_name: dc2_object.DC2ObjectCatalog
 base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1i/dpdd/calexp-v1:coadd-dr1b-v1/object_table_summary
 schema_filename: schema.yaml
 filename_pattern: 'object_tract_\d+\.hdf5$'
-description: DC2 Run 2.1i Object Catalog (with only DPDD columns and native columns needed for the DPDD columns)
+description: DC2 Run 2.1i DR1b Object Catalog
 creators: ['DESC DC2 Team']
 pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_tract4850.yaml
@@ -5,4 +5,3 @@ filename_pattern: 'trim_object_tract_4850\.hdf5$'
 description: DC2 Run 2.1i Object Catalog Tract 4850 (with only DPDD columns and native columns needed for the DPDD columns)
 creators: ['DESC DC2 Team']
 pixel_scale: 0.2
-include_in_default_catalog_list: true


### PR DESCRIPTION
This PR basically makes `dc2_object_run2.1i_dr1` an alias of `dc2_object_run2.1i_dr1b_parquet` and makes some related fixes. 

Note this is a backward incompatible change as the iteration is now by tracts, not by tracts and patches. 