### PR TITLE
add Run2.1i object catalogs for DR4

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4.yaml
@@ -1,0 +1,2 @@
+alias: dc2_object_run2.1i_dr4_all_columns
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4_all_columns.yaml
@@ -1,0 +1,7 @@
+subclass_name: dc2_object.DC2ObjectCatalog
+base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1i/dpdd/calexp-v1:coadd-dr4-v1/object_table_summary
+schema_filename: schema.yaml
+filename_pattern: 'object_tract_\d+\.hdf5$'
+description: DC2 Run 2.1i Object Catalog (DR4)
+creators: ['DESC DC2 Team']
+pixel_scale: 0.2

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4_tract4850.yaml
@@ -1,0 +1,1 @@
+alias: dc2_object_run2.1i_dr4_tract4850_all_columns

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4_tract4850_all_columns.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4_tract4850_all_columns.yaml
@@ -1,0 +1,3 @@
+based_on: dc2_object_run2.1i_dr4_all_columns
+filename_pattern: 'object_tract_4850\.hdf5$'
+description: DC2 Run 2.1i Object Catalog (DR4) with only tract 4850


### PR DESCRIPTION
This PR adds Run2.1i object catalogs for DR4 (HDF5, all columns). It addresses #352 but not fully, as we would like to move onto parquet format in the end.