### PR TITLE
update dr1a metacal configs to improve performance

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_metacal_griz_run2.1i_dr1a_tract4850.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_metacal_griz_run2.1i_dr1a_tract4850.yaml
@@ -1,8 +1,0 @@
-subclass_name: dc2_metacal.DC2MetacalCatalog
-base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1i/dpdd/calexp-v1:coadd-v1/metacal_griz_catalog
-schema_filename: schema.yaml
-filename_pattern: 'metacal_tract_4850.parquet$'
-description: DC2 Run 2.1i coadd v1 Metacal Catalog (griz)
-creators: ['Francois Lanusse', 'Johann Cohen-Tanugi']
-bands: 'griz'
-apply_metacal_test3_fix: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_tract4850_with_metacal_griz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_tract4850_with_metacal_griz.yaml
@@ -3,7 +3,7 @@ description: DC2 Run 2.1i Object Catalog with metacal (griz)
 catalogs:
   - catalog_name: dc2_object_run2.1i_dr1a_all_columns
     filename_pattern: 'object_tract_4850\.hdf5$'
-    matching_method: 'id'
-  - catalog_name: dc2_metacal_griz_run2.1i_dr1a_tract4850
-    matching_method: 'id'
-
+    matching_method: MATCHING_ORDER
+  - catalog_name: dc2_metacal_griz_run2.1i_dr1a
+    filename_pattern: 'metacal_tract_4850\.parquet$'
+    matching_method: MATCHING_ORDER

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_tract4850_with_metacal_griz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_tract4850_with_metacal_griz.yaml
@@ -3,6 +3,7 @@ description: DC2 Run 2.1i Object Catalog with metacal (griz)
 catalogs:
   - catalog_name: dc2_object_run2.1i_dr1a_all_columns
     filename_pattern: 'object_tract_4850\.hdf5$'
+    matching_method: id
   - catalog_name: dc2_metacal_griz_run2.1i_dr1a
     filename_pattern: 'metacal_tract_4850\.parquet$'
-    matching_method: MATCHING_ORDER
+    matching_method: id

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_tract4850_with_metacal_griz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_tract4850_with_metacal_griz.yaml
@@ -3,7 +3,6 @@ description: DC2 Run 2.1i Object Catalog with metacal (griz)
 catalogs:
   - catalog_name: dc2_object_run2.1i_dr1a_all_columns
     filename_pattern: 'object_tract_4850\.hdf5$'
-    matching_method: MATCHING_ORDER
   - catalog_name: dc2_metacal_griz_run2.1i_dr1a
     filename_pattern: 'metacal_tract_4850\.parquet$'
     matching_method: MATCHING_ORDER

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_with_metacal_griz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_with_metacal_griz.yaml
@@ -3,6 +3,5 @@ description: DC2 Run 2.1i Object Catalog with metacal (griz)
 catalogs:
   - catalog_name: dc2_object_run2.1i_dr1a_all_columns
     use_cache: false
-    matching_method: MATCHING_ORDER
   - catalog_name: dc2_metacal_griz_run2.1i_dr1a
     matching_method: MATCHING_ORDER

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_with_metacal_griz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_with_metacal_griz.yaml
@@ -3,5 +3,6 @@ description: DC2 Run 2.1i Object Catalog with metacal (griz)
 catalogs:
   - catalog_name: dc2_object_run2.1i_dr1a_all_columns
     use_cache: false
+    matching_method: id
   - catalog_name: dc2_metacal_griz_run2.1i_dr1a
-    matching_method: MATCHING_ORDER
+    matching_method: id

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_with_metacal_griz.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a_with_metacal_griz.yaml
@@ -2,7 +2,7 @@ subclass_name: composite.CompositeReader
 description: DC2 Run 2.1i Object Catalog with metacal (griz)
 catalogs:
   - catalog_name: dc2_object_run2.1i_dr1a_all_columns
-    matching_method: 'id'
+    use_cache: false
+    matching_method: MATCHING_ORDER
   - catalog_name: dc2_metacal_griz_run2.1i_dr1a
-    matching_method: 'id'
-
+    matching_method: MATCHING_ORDER


### PR DESCRIPTION
This PR updates dr1a metacal configs to improve performance, in particular:
1. turns off `use_cache` for the full object catalog (fix #355)
2. use `MATCHING_ORDER` instead of `ID` for matching. I believe that, even though the iteration scheme is different in the add-on, the order of records is still the same. In this case, `MATCHING_ORDER` will give better performance. @EiffL can you test and confirm this works?