### PR TITLE
allows customized dataset "info" (tract, visit, etc; parsed from filename) for `DC2DMCatalog`

### DIFF
--- a/GCRCatalogs/dc2_dia_object.py
+++ b/GCRCatalogs/dc2_dia_object.py
@@ -6,7 +6,7 @@ import os
 
 import numpy as np
 
-from .dc2_dm_catalog import (DC2DMCatalog,
+from .dc2_dm_catalog import (DC2DMTractCatalog,
                              convert_nanoJansky_to_mag,
                              convert_flux_err_to_mag_err,
                              create_basic_flag_mask)
@@ -14,7 +14,7 @@ from .dc2_dm_catalog import (DC2DMCatalog,
 __all__ = ['DC2DiaObjectCatalog']
 
 
-class DC2DiaObjectCatalog(DC2DMCatalog):
+class DC2DiaObjectCatalog(DC2DMTractCatalog):
     r"""DC2 DIA Object Catalog reader
 
     Parameters
@@ -33,8 +33,7 @@ class DC2DiaObjectCatalog(DC2DMCatalog):
     """
     # pylint: disable=too-many-instance-attributes
     FILE_DIR = os.path.dirname(os.path.abspath(__file__))
-    FILE_PATTERN = r'dia_object_\d+\.parquet$'
-    SCHEMA_FILENAME = 'schema.yaml'
+    FILE_PATTERN = r'dia_object_tract_\d+\.parquet$'
     META_PATH = os.path.join(FILE_DIR, 'catalog_configs/_dc2_dia_object_meta.yaml')
 
     @staticmethod

--- a/GCRCatalogs/dc2_dia_source.py
+++ b/GCRCatalogs/dc2_dia_source.py
@@ -6,12 +6,12 @@ import os
 
 import numpy as np
 
-from .dc2_dm_catalog import DC2DMCatalog, convert_flux_to_nanoJansky, create_basic_flag_mask
+from .dc2_dm_catalog import DC2DMVisitCatalog, convert_flux_to_nanoJansky, create_basic_flag_mask
 
 __all__ = ['DC2DiaSourceCatalog']
 
 
-class DC2DiaSourceCatalog(DC2DMCatalog):
+class DC2DiaSourceCatalog(DC2DMVisitCatalog):
     r"""DC2 DIA Source Catalog reader
 
     Parameters
@@ -32,7 +32,6 @@ class DC2DiaSourceCatalog(DC2DMCatalog):
 
     FILE_DIR = os.path.dirname(os.path.abspath(__file__))
     FILE_PATTERN = r'dia_src_visit_\d+\.parquet$'
-    SCHEMA_FILENAME = 'schema.yaml'
     META_PATH = os.path.join(FILE_DIR, 'catalog_configs/_dc2_dia_source_meta.yaml')
 
     @staticmethod

--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -293,7 +293,7 @@ class DC2DMTractCatalog(DC2DMCatalog):
         match = re.search(r'tract_(\d+)', filename)
         if match is None:
             raise ValueError('Filename format not expected!')
-        return {'tract': int(match.groups[0])}
+        return {'tract': int(match.groups()[0])}
 
     @staticmethod
     def _sort_datasets(datasets):

--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -317,7 +317,7 @@ class DC2DMVisitCatalog(DC2DMCatalog):
         match = re.search(r'visit_(\d+)', filename)
         if match is None:
             raise ValueError('Filename format not expected!')
-        return {'visit': int(match.groups[0])}
+        return {'visit': int(match.groups()[0])}
 
     @staticmethod
     def _sort_datasets(datasets):

--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -285,6 +285,7 @@ class DC2DMCatalog(BaseGenericCatalog):
 
 
 class DC2DMTractCatalog(DC2DMCatalog):
+    _native_filter_quantities = {'tract'}
     FILE_PATTERN = r'.+_tract_\d+\.parquet$'
 
     @staticmethod
@@ -308,6 +309,7 @@ class DC2DMTractCatalog(DC2DMCatalog):
 
 
 class DC2DMVisitCatalog(DC2DMCatalog):
+    _native_filter_quantities = {'visit'}
     FILE_PATTERN = r'.+_visit_\d+\.parquet$'
 
     @staticmethod

--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -304,7 +304,7 @@ class DC2DMTractCatalog(DC2DMCatalog):
         Returns:
             A sorted list of available tracts as integers
         """
-        return [dataset.tract for dataset in self._datasets]
+        return [dataset.info['tract'] for dataset in self._datasets]
 
 
 class DC2DMVisitCatalog(DC2DMCatalog):
@@ -327,4 +327,4 @@ class DC2DMVisitCatalog(DC2DMCatalog):
         Returns:
             A sorted list of available visits as integers
         """
-        return [dataset.visit for dataset in self._datasets]
+        return [dataset.info['visit'] for dataset in self._datasets]

--- a/GCRCatalogs/dc2_forced_source.py
+++ b/GCRCatalogs/dc2_forced_source.py
@@ -4,12 +4,12 @@ DC2 Forced Source Catalog Reader
 
 import os
 
-from .dc2_dm_catalog import DC2DMCatalog, convert_flux_to_nanoJansky, create_basic_flag_mask
+from .dc2_dm_catalog import DC2DMVisitCatalog, convert_flux_to_nanoJansky, create_basic_flag_mask
 
 __all__ = ['DC2ForcedSourceCatalog']
 
 
-class DC2ForcedSourceCatalog(DC2DMCatalog):
+class DC2ForcedSourceCatalog(DC2DMVisitCatalog):
     r"""DC2 Forced Source Catalog reader
 
     Parameters
@@ -30,7 +30,6 @@ class DC2ForcedSourceCatalog(DC2DMCatalog):
 
     FILE_DIR = os.path.dirname(os.path.abspath(__file__))
     FILE_PATTERN = r'fourced_source_visit_\d+\.parquet$'
-    SCHEMA_FILENAME = 'schema.yaml'
     META_PATH = os.path.join(FILE_DIR, 'catalog_configs/_dc2_forced_source_meta.yaml')
 
     @staticmethod

--- a/GCRCatalogs/dc2_metacal.py
+++ b/GCRCatalogs/dc2_metacal.py
@@ -4,12 +4,12 @@ DC2 Metacal Catalog Reader
 
 import os
 import numpy as np
-from .dc2_dm_catalog import DC2DMCatalog
+from .dc2_dm_catalog import DC2DMTractCatalog
 
 __all__ = ['DC2MetacalCatalog']
 
 
-class DC2MetacalCatalog(DC2DMCatalog):
+class DC2MetacalCatalog(DC2DMTractCatalog):
     r"""DC2 Metacal Catalog reader
 
     Parameters

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -13,7 +13,7 @@ import pandas as pd
 import yaml
 from GCR import BaseGenericCatalog
 
-from .dc2_dm_catalog import DC2DMCatalog
+from .dc2_dm_catalog import DC2DMTractCatalog
 
 __all__ = ['DC2ObjectCatalog', 'DC2ObjectParquetCatalog']
 
@@ -633,7 +633,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
         return self._len
 
 
-class DC2ObjectParquetCatalog(DC2DMCatalog):
+class DC2ObjectParquetCatalog(DC2DMTractCatalog):
     r"""DC2 Object (Parquet) Catalog reader
 
     Parameters

--- a/GCRCatalogs/dc2_source.py
+++ b/GCRCatalogs/dc2_source.py
@@ -6,12 +6,12 @@ import os
 
 import numpy as np
 
-from .dc2_dm_catalog import DC2DMCatalog, convert_flux_to_nanoJansky, create_basic_flag_mask
+from .dc2_dm_catalog import DC2DMVisitCatalog, convert_flux_to_nanoJansky, create_basic_flag_mask
 
 __all__ = ['DC2SourceCatalog']
 
 
-class DC2SourceCatalog(DC2DMCatalog):
+class DC2SourceCatalog(DC2DMVisitCatalog):
     r"""DC2 Source Catalog reader
 
     Parameters


### PR DESCRIPTION
This PR fixes a bug that was introduced in v0.13.0 when the `DC2DMCatalog` is updated. The filenames of `DC2DMCatalog` files contain some header information (tracts, visits, etc) but it was assumed to be just tract in the previous edit. This PR fixes this issue. In particular, now customized dataset "info" are allowed. 

For convenience, two derived classes `DC2DMTractCatalog` and `DC2DMVisitCatalog` for catalogs that are split in tract/visit, respectively. 

I have not yet tested this PR at all, so I'm opening as a draft PR for now. I'm still  assigning a reviewer for early iteration. 