### PR TITLE
Put super() init to end of DC2DMVisitCatalog _subclass_init.

### DIFF
--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -335,7 +335,6 @@ class DC2DMVisitCatalog(DC2DMCatalog):
     FILE_PATTERN = r'.+_visit_\d+\.parquet$'
 
     def _subclass_init(self, **kwargs):
-        super()._subclass_init(**kwargs)
         self._visits = None
         if 'visit' in kwargs and 'visits' in kwargs:
             raise ValueError('Conflict options (visit and visits) defined')
@@ -343,6 +342,7 @@ class DC2DMVisitCatalog(DC2DMCatalog):
             self._visits = [int(kwargs['visit'])]
         if 'visits' in kwargs:
             self._visits = [int(t) for t in kwargs['visits']]
+        super()._subclass_init(**kwargs)
 
     def _extract_dataset_info(self, filename):
         match = re.search(r'visit_(\d+)', filename)


### PR DESCRIPTION
Fixes error reading DIA Source Object catalog, e.g., `dc2_dia_source_run1.2p_test`

Moves `super` init to end of `_subclass_init` so that `self._visits` is defined when super init is run.

> If this pull request is to address specific issues, please add "fix #ISSUE_NUMBER" below so that when this PR is merged, the associated issues will be automatically closed. Always use a short but descriptive title; avoid using "issues/xxx" as title.

fix #366 