### PR TITLE
Rewrite _generate_modifiers for Parquet Object Catalog to calculate magnitudes.

### DIFF
--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -22,6 +22,15 @@ __all__ = ['DC2DMCatalog', 'DC2DMTractCatalog', 'DC2DMVisitCatalog']
 
 
 #pylint: disable=C0103
+def convert_flux_to_mag(flux, fluxmag0):
+    """Convert calibrated flux to AB mag.
+    """
+    flux_nJ = convert_flux_to_nanoJansky(flux, fluxmag0)
+    mag_AB = convert_nanoJansky_to_mag(flux_nJ)
+    return mag_AB
+
+
+#pylint: disable=C0103
 def convert_nanoJansky_to_mag(flux):
     """Convert calibrated nanoJansky flux to AB mag.
     """

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -754,14 +754,16 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
                                            f'{band}_slot_PsfFlux_{FLUX}',
                                            f'{band}_slot_PsfFlux_{FLUX}{ERR}')
 
-            modifiers[f'cModelFlux_{band}'] = (convert_dm_ref_zp_flux_to_nanoJansky,
-                                               f'{band}_modelfit_CModel_{FLUX}')
-            modifiers[f'cModelFluxErr_{band}'] = (convert_dm_ref_zp_flux_to_nanoJansky,
-                                                  f'{band}_modelfit_CModel_{FLUX}{ERR}')
-            modifiers[f'cModelFlux_flag_{band}'] = (convert_flux_err_to_mag_err,
-                                                    f'{band}_modelfit_CModel_flag')
-            modifiers[f'mag_{band}_cModel'] = (convert_dm_ref_zp_flux_to_mag,
-                                               f'{band}_modelfit_CModel_{FLUX}')
+            modifiers[f'cModelFlux_{band}'] = (convert_flux_to_nanoJansky,
+                                               f'{band}_modelfit_CModel_{FLUX}',
+                                               f'{band}_FLUXMAG0')
+            modifiers[f'cModelFluxErr_{band}'] = (convert_flux_to_nanoJansky,
+                                                  f'{band}_modelfit_CModel_{FLUX}{ERR}',
+                                                  f'{band}_FLUXMAG0')
+            modifiers[f'cModelFlux_flag_{band}'] = f'{band}_modelfit_CModel_flag'
+            modifiers[f'mag_{band}_cModel'] = (convert_flux_to_mag,
+                                               f'{band}_modelfit_CModel_{FLUX}',
+                                               f'{band}_FLUXMAG0')
             modifiers[f'magerr_{band}_cModel'] = (convert_flux_err_to_mag_err,
                                                   f'{band}_modelfit_CModel_{FLUX}',
                                                   f'{band}_modelfit_CModel_{FLUX}{ERR}')

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -673,7 +673,7 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
                 self.pixel_scale, bands)
 
     @staticmethod
-    def _generate_modifiers(pixel_scale=0.2, bands='ugrizy'):
+    def _generate_modifiers(pixel_scale=0.2, bands='ugrizy'):  # pylint: disable=arguments-differ
         """Creates a dictionary relating native and homogenized column names
 
         Args:
@@ -726,10 +726,12 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
 
         for band in bands:
             modifiers[f'psFlux_{band}'] = (convert_flux_to_nanoJansky,
-                                           f'{band}_base_PsfFlux_{FLUX}')
+                                           f'{band}_base_PsfFlux_{FLUX}',
+                                           f'{band}_FLUXMAG0')
             modifiers[f'psFlux_flag_{band}'] = f'{band}_base_PsfFlux_flag'
-            modifiers[f'psFluxErr_{band}'] = (convert_dm_ref_zp_flux_to_nanoJansky,
-                                              f'{band}_base_PsfFlux_{FLUX}{ERR}')
+            modifiers[f'psFluxErr_{band}'] = (convert_flux_to_nanoJansky,
+                                              f'{band}_base_PsfFlux_{FLUX}{ERR}',
+                                              f'{band}_FLUXMAG0')
             modifiers[f'mag_{band}'] = (convert_nanoJansky_to_mag,
                                         f'psFlux_{band}')
             modifiers[f'magerr_{band}'] = (convert_flux_err_to_mag_err,
@@ -760,4 +762,3 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
                 f'IxxPSF_{band}', f'IyyPSF_{band}', f'IxyPSF_{band}')
 
         return modifiers
-

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -777,6 +777,8 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
 
             modifiers[f'psf_fwhm_{band}'] = (
                 lambda xx, yy, xy: pixel_scale * 2.355 * (xx * yy - xy * xy) ** 0.25,
-                f'IxxPSF_{band}', f'IyyPSF_{band}', f'IxyPSF_{band}')
+                f'{band}_base_SdssShape_xx',
+                f'{band}_base_SdssShape_yy',
+                f'{band}_base_SdssShape_xy')
 
         return modifiers

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -404,14 +404,11 @@ class DC2ObjectCatalog(BaseGenericCatalog):
             if not has_modelfit_mag:
                 # The zp=27.0 is based on the default calibration for the coadds
                 # as specified in the DM code.  It's correct for Run 1.1p.
-                modifiers['mag_{}_cModel'.format(band)] = (
-                    lambda x: -2.5 * np.log10(x) + 27.0,
-                    '{}_modelfit_CModel_{}'.format(band, FLUX),
-                )
-                modifiers['magerr_{}_cModel'.format(band)] = (
-                    lambda flux, err: (2.5 * err) / (flux * np.log(10)),
-                    '{}_modelfit_CModel_{}'.format(band, FLUX),
-                    '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR),
+                modifiers['mag_{}_cModel'.format(band)] = (convert_dm_ref_zp_flux_to_mag,
+                                                           'mag_{}_cModel'.format(band))
+                modifiers['magerr_{}_cModel'.format(band)] = (convert_flux_err_to_mag_err,
+                                                              '{}_modelfit_CModel_{}'.format(band, FLUX),
+                                                              '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR),
                 )
                 modifiers['snr_{}_cModel'.format(band)] = (
                     np.divide,


### PR DESCRIPTION
Generate all magnitudes from flux quantitites.
Does not retain the complicated dm_schema_version, has_modelfit_mag
logic for the new Parquet Object files.  Those are presently not needed.

> If this pull request is to address specific issues, please add "fix #ISSUE_NUMBER" below so that when this PR is merged, the associated issues will be automatically closed. Always use a short but descriptive title; avoid using "issues/xxx" as title.

fix #369 