### PR TITLE
agn reader and config file

### DIFF
--- a/GCRCatalogs/agn.py
+++ b/GCRCatalogs/agn.py
@@ -1,0 +1,73 @@
+"""
+AGN catalog class.
+"""
+from __future__ import division, print_function
+import os
+import h5py
+import numpy as np
+from GCR import BaseGenericCatalog
+
+__all__ = ['AGNCatalog']
+
+def _calc_flux(mag):
+    return np.power(10, -0.4*mag)
+
+def _calc_mag_sum(mag1, mag2):
+    total_flux =  _calc_flux(mag1) +  _calc_flux(mag2)
+    return -2.5*np.log10(total_flux)
+
+class AGNCatalog(BaseGenericCatalog):
+    """
+    AGN catalog class.  Uses generic quantity and filter mechanisms
+    defined by BaseGenericCatalog class.
+    """
+
+    def _subclass_init(self, base_dir, filename, **kwargs): #pylint: disable=W0221
+
+        if not os.path.isdir(base_dir):
+            raise RuntimeError("Catalog directory %s does not exist." % (catalog_root_dir))
+
+        self._path = os.path.join(base_dir, filename)
+        self._handle = h5py.File(self._path)
+        self._quantity_modifiers = self._generate_quantity_modifiers()
+        self.lightcone = kwargs.get('lightcone', True)
+        self.sky_area = kwargs.get('sky_area', None)
+        
+    def __del__(self):
+        self._handle.close()
+
+    def _generate_quantity_modifiers(self):
+        quantity_modifiers = {
+            'blackHoleEddingtonRatio': 'blackHoleEddingtonRatio',
+            'blackHoleMass':           'blackHoleMass',
+            'dec':                     'dec',
+            'galaxy_id':               'galaxy_id',
+            'halo_mass':               'halo_mass',
+            'is_central':              'is_central',
+            'ra':                      'ra',
+            'redshift':                'redshift',
+            'redshift_true':           'redshift',
+        }
+
+        # magnitudes
+        for band in ['u', 'g', 'r', 'i', 'z', 'y']:
+            quantity_modifiers['mag_{}_noagn_lsst'.format(band)] = 'mag_{}_lsst(galaxy)'.format(band)
+            quantity_modifiers['agn_{}_lsst'.format(band)] = 'mag_{}_lsst(agn)'.format(band)
+            quantity_modifiers['mag_{}_lsst'.format(band)] = (_calc_mag_sum,
+                                                              'mag_{}_lsst(galaxy)'.format(band),
+                                                              'mag_{}_lsst(agn)'.format(band),
+                                                              )
+            quantity_modifiers['mag_{}_sdss'.format(band)] = (_calc_mag_sum,
+                                                              'mag_{}_lsst(galaxy)'.format(band),
+                                                              'mag_{}_lsst(agn)'.format(band),
+                                                              )
+
+        return quantity_modifiers
+
+    def _iter_native_dataset(self, native_filters=None):
+        if native_filters is not None:
+            raise RuntimeError("*native_filters* not supported")
+        yield lambda x: self._handle[x][()]
+
+    def _generate_native_quantity_list(self):
+        return list(self._handle.keys())

--- a/GCRCatalogs/agn.py
+++ b/GCRCatalogs/agn.py
@@ -57,10 +57,6 @@ class AGNCatalog(BaseGenericCatalog):
                                                               'mag_{}_lsst(galaxy)'.format(band),
                                                               'mag_{}_lsst(agn)'.format(band),
                                                               )
-            quantity_modifiers['mag_{}_sdss'.format(band)] = (_calc_mag_sum,
-                                                              'mag_{}_lsst(galaxy)'.format(band),
-                                                              'mag_{}_lsst(agn)'.format(band),
-                                                              )
 
         return quantity_modifiers
 

--- a/GCRCatalogs/agn.py
+++ b/GCRCatalogs/agn.py
@@ -25,7 +25,7 @@ class AGNCatalog(BaseGenericCatalog):
     def _subclass_init(self, base_dir, filename, **kwargs): #pylint: disable=W0221
 
         if not os.path.isdir(base_dir):
-            raise RuntimeError("Catalog directory %s does not exist." % (catalog_root_dir))
+            raise RuntimeError("Catalog directory %s does not exist." % (base_dir))
 
         self._path = os.path.join(base_dir, filename)
         self._handle = h5py.File(self._path)

--- a/GCRCatalogs/catalog_configs/AGN_mean_mags_v1.1.4.yaml
+++ b/GCRCatalogs/catalog_configs/AGN_mean_mags_v1.1.4.yaml
@@ -1,0 +1,17 @@
+subclass_name: agn.AGNCatalog
+
+base_dir: /global/projecta/projectdirs/lsst/groups/SSim/DC2/cosmoDC2_v1.1.4
+filename: agn_mean_mags.h5
+
+sky_area: 439.78987
+
+cosmology:
+  H0: 71.0
+  Om0: 0.2648
+  Ob0: 0.0448
+  sigma8: 0.8
+  n_s: 0.963
+
+creators: ['Scott Daniel']
+description: |
+  AGN mean magnitudes added to instance catalogs for image simulation run on cosmoDC2 v1.1.4.


### PR DESCRIPTION
> If this pull request is to address specific issues, please add "fix #ISSUE_NUMBER" below so that when this PR is merged, the associated issues will be automatically closed. Always use a short but descriptive title; avoid using "issues/xxx" as title.
This PR addresses the first step outlined in issue/15. With help from @yymao, the stand-alone reader for the agn-mean-mags catalog provided by Scott Daniel is complete. It has been tested in this [notebook](https://github.com/LSSTDESC/DC2-analysis/blob/u/kovacs/agn/contributed/agn.ipynb). The current implementation sums the fluxes coming from the galactic and agn components and computes the resulting magnitude, which is delivered as a schema quantity mag_*_lsst. It has also been run in DESCQA. Test results: [Color distributions without AGN contributions](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2019-08-07_1 ) (note LSST filters are used in place of SDSS filters for the AGN catalog) and [Color distributions with AGN contributions](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2019-08-07_2) 