### PR TITLE
allows multi-character filters in object catalog reader

### DIFF
--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -678,8 +678,7 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
         if kwargs.get('is_dpdd'):
             self._quantity_modifiers = {col: None for col in self._columns}
         else:
-            # The following is in principle fragile, but in practice we
-            bands = [col[0] for col in self._columns if len(col) == 10 and col.endswith('_FLUXMAG0')]
+            bands = [col.rpartition('_')[0] for col in self._columns if col.endswith('_FLUXMAG0')]
 
             self._quantity_modifiers = self._generate_modifiers(
                 self.pixel_scale, bands)


### PR DESCRIPTION
This PR allows multi-character filters in object catalog reader (such as `i2`). 