### PR TITLE
exclude internal column names when extracting columns from parquet files

### DIFF
--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -129,7 +129,8 @@ class ParquetFileWrapper():
     @property
     def columns(self):
         if self._columns is None:
-            self._columns = self.handle.schema.names
+            self._columns = [col for col in self.handle.schema.names
+                             if re.match(r'__\w+__$', col) is None]
         return list(self._columns)
 
 


### PR DESCRIPTION
@boutigny reported that there's error when loading all quantities from the metacal catalog for 2.1i DR1b (in parquet format). Tracking down the offending columns, I found that there is an unexpected column called `__index_level_0__` in the metacal catalog. This is an internal column used by pandas that probably should not have been saved in the parquet file.

In any case, this column is not loadable, and hence should be excluded when the reader generates the list the native columns. This PR fixes this issue. 