### PR TITLE
Add config files for DC2 Run 2.1.1i metacal catalogs 

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_metacal_run2.1.1i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_metacal_run2.1.1i.yaml
@@ -1,0 +1,4 @@
+subclass_name: dc2_metacal.DC2MetacalCatalog
+base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1.1i/dpdd/calexp-v1:coadd-v1/metacal_table_summary/final
+filename_pattern: 'metacal_tract_\d+\.parquet$'
+description: DC2 Run 2.1.1i Metacal Table

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1.1i_with_metacal.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1.1i_with_metacal.yaml
@@ -1,0 +1,7 @@
+subclass_name: composite.CompositeReader
+description: DC2 Run 2.1.1i Object Catalog with metacal
+catalogs:
+  - catalog_name: dc2_object_run2.1.1i
+    matching_method: 'id'
+  - catalog_name: dc2_metacal_run2.1.1i
+    matching_method: 'id'


### PR DESCRIPTION
Addition of new yaml configuration files to /catalog_configs/ to include the new DC2 Run 2.1.1i metacal catalogs. 

The DC2 Run 2.1.1i object catalog config was already added as part of https://github.com/LSSTDESC/gcr-catalogs/commit/d902ebaaf1761645a5250c35b6716cf478306b90 . This PR adds the DC2 Run 2.1.1i metacal catalog as well as a Composite object+metacal catalog.