### PR TITLE
Update dc2_metacal_run2.1.1i.yaml

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_metacal_run2.1.1i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_metacal_run2.1.1i.yaml
@@ -1,4 +1,8 @@
 subclass_name: dc2_metacal.DC2MetacalCatalog
 base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1.1i/dpdd/calexp-v1:coadd-v1/metacal_table_summary/final
+schema_filename: schema.yaml
 filename_pattern: 'metacal_tract_\d+\.parquet$'
 description: DC2 Run 2.1.1i Metacal Table
+creators: ['Johann Cohen-Tanugi']
+bands: 'griz'
+apply_metacal_test3_fix: true

--- a/GCRCatalogs/catalog_configs/dc2_metacal_run2.1.1i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_metacal_run2.1.1i.yaml
@@ -1,6 +1,5 @@
 subclass_name: dc2_metacal.DC2MetacalCatalog
 base_dir: /global/projecta/projectdirs/lsst/production/DC2_ImSim/Run2.1.1i/dpdd/calexp-v1:coadd-v1/metacal_table_summary/final
-schema_filename: schema.yaml
 filename_pattern: 'metacal_tract_\d+\.parquet$'
 description: DC2 Run 2.1.1i Metacal Table
 creators: ['Johann Cohen-Tanugi']


### PR DESCRIPTION
I forgot that the optional arguments in the reader are actually important. As far as I know, we still need the flux correction, and we are now using the 4 bands g r i z.
@maho3 I'm sorry, I should have thought of it when reviewing your PR, can you just confirm that there was no particular reason for not including these in the first place?
