### PR TITLE
Fix the definition of mag_{}_cModel for HDF5 DC2ObjectCatalog

### DIFF
--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -302,7 +302,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
             bands = [col[0] for col in self._schema if len(col) == 5 and col.endswith('_mag')]
 
             self._quantity_modifiers = self._generate_modifiers(
-                    self.pixel_scale, bands, has_modelfit_mag, dm_schema_version)
+                self.pixel_scale, bands, has_modelfit_mag, dm_schema_version)
 
         self._quantity_info_dict = self._generate_info_dict(META_PATH, bands)
         self._len = None
@@ -408,8 +408,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
                                                            '{}_modelfit_CModel_{}'.format(band, FLUX))
                 modifiers['magerr_{}_cModel'.format(band)] = (convert_flux_err_to_mag_err,
                                                               '{}_modelfit_CModel_{}'.format(band, FLUX),
-                                                              '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR),
-                )
+                                                              '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR))
                 modifiers['snr_{}_cModel'.format(band)] = (
                     np.divide,
                     '{}_modelfit_CModel_{}'.format(band, FLUX),

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -405,7 +405,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
                 # The zp=27.0 is based on the default calibration for the coadds
                 # as specified in the DM code.  It's correct for Run 1.1p.
                 modifiers['mag_{}_cModel'.format(band)] = (convert_dm_ref_zp_flux_to_mag,
-                                                           'mag_{}_cModel'.format(band))
+                                                           '{}_modelfit_CModel_{}'.format(band, FLUX))
                 modifiers['magerr_{}_cModel'.format(band)] = (convert_flux_err_to_mag_err,
                                                               '{}_modelfit_CModel_{}'.format(band, FLUX),
                                                               '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR),


### PR DESCRIPTION
This PR fixes a bug that was introduced (by me) in cc8bbc14 as part of #369.

There was a bug where `mag_{}_cmodel` was defined based on `mag_{}_cModel`

This PR fixes it to be `{}_modelfit_CModel_{}.format(band, FLUX)` as it should have been (and should be).

This should have only affected Run 1.1p and HSC catalogs.
because it was triggered if the modelfit mags were not already calculated
and only for the default (HDF5) catalogs.

The Parquet class was fine.
