### PR TITLE
minor fixes to object catalog reader to make linter happy

### DIFF
--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -141,7 +141,6 @@ class DC2DMCatalog(BaseGenericCatalog):
     ----------
     base_dir          (str): Directory of data files being served, required
     filename_pattern  (str): The optional regex pattern of served data files
-    use_cache        (bool): Cache read data in memory
     is_dpdd          (bool): File are already in DPDD-format.  No translation.
 
     Attributes

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -658,16 +658,12 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
     Attributes
     ----------
     base_dir          (str): The directory of data files being served
-
-    Notes
-    -----
     """
-    # pylint: disable=too-many-instance-attributes
-    FILE_DIR = FILE_DIR
-    FILE_PATTERN = r'object_tract_\d+\.parquet$'
-    META_PATH = META_PATH
 
     def _subclass_init(self, **kwargs):
+
+        self.FILE_PATTERN = r'object_tract_\d+\.parquet$'
+        self.META_PATH = META_PATH
 
         # hack to skip the call of `_generate_modifiers` in the base class
         # TODO: fix this some day


### PR DESCRIPTION
The linter thinks that we are assigning `FILE_DIR` and `META_PATH` to themselves, which is a valid concern. This PR fixes this, and also cleans up some docstring since I noticed them. 

This PR should fix the travis CI test in #390 and #391. 