### PR TITLE
Add object and metacal catalog configs for Run2.2i DR3

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_metacal_run2.2i_dr3.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_metacal_run2.2i_dr3.yaml
@@ -1,0 +1,5 @@
+subclass_name: dc2_metacal.DC2MetacalCatalog
+base_dir: /global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/dpdd/Run2.2i-dr3/metacal_table_summary
+filename_pattern: 'metacal_tract_\d+\.parquet$'
+description: DC2 Run 2.2i DR3 Metacal Table
+creators: ['Johann Cohen-Tanugi']

--- a/GCRCatalogs/catalog_configs/dc2_metacal_run2.2i_dr3.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_metacal_run2.2i_dr3.yaml
@@ -2,4 +2,4 @@ subclass_name: dc2_metacal.DC2MetacalCatalog
 base_dir: /global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/dpdd/Run2.2i-dr3/metacal_table_summary
 filename_pattern: 'metacal_tract_\d+\.parquet$'
 description: DC2 Run 2.2i DR3 Metacal Table
-creators: ['Johann Cohen-Tanugi']
+creators: ['DESC DC2 Team']

--- a/GCRCatalogs/catalog_configs/dc2_metacal_run2.2i_dr3.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_metacal_run2.2i_dr3.yaml
@@ -1,5 +1,7 @@
 subclass_name: dc2_metacal.DC2MetacalCatalog
 base_dir: /global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/dpdd/Run2.2i-dr3/metacal_table_summary
 filename_pattern: 'metacal_tract_\d+\.parquet$'
+bands: 'griz'
+apply_metacal_test3_fix: true
 description: DC2 Run 2.2i DR3 Metacal Table
 creators: ['DESC DC2 Team']

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr3.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr3.yaml
@@ -1,0 +1,7 @@
+subclass_name: dc2_object.DC2ObjectParquetCatalog
+base_dir: /global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/dpdd/Run2.2i-dr3/object_table_summary
+filename_pattern: 'object_tract_\d+\.parquet$'
+description: DC2 Run 2.2i DR3 Object Table
+creators: ['DESC DC2 Team']
+pixel_scale: 0.2
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr3_tract3830.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr3_tract3830.yaml
@@ -1,0 +1,3 @@
+based_on: dc2_object_run2.2i_dr3
+tract: 3830
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr3_with_metacal.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr3_with_metacal.yaml
@@ -2,8 +2,11 @@ subclass_name: composite.CompositeReader
 description: DC2 Run 2.2i DR3 Object Catalog with metacal
 catalogs:
   - catalog_name: dc2_object_run2.2i_dr3
-    filename_pattern: 'object_tract_(?!3083|4641|4850)\d+\.parquet$'
+    # excluding some tracts due to missing patches in metacal catalog (as of March 11, 2020)
+    filename_pattern: 'object_tract_(?!3079|4034|4232|4636|5066|5073)\d+\.parquet$'
     matching_method: MATCHING_FORMAT
   - catalog_name: dc2_metacal_run2.2i_dr3
+    # excluding some tracts due to missing patches in metacal catalog (as of March 11, 2020)
+    filename_pattern: 'metacal_tract_(?!3079|4034|4232|4636|5066|5073)\d+\.parquet$'
     matching_method: MATCHING_FORMAT
 include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr3_with_metacal.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr3_with_metacal.yaml
@@ -1,0 +1,8 @@
+subclass_name: composite.CompositeReader
+description: DC2 Run 2.2i DR3 Object Catalog with metacal
+catalogs:
+  - catalog_name: dc2_object_run2.2i_dr3
+    matching_method: MATCHING_FORMAT
+  - catalog_name: dc2_metacal_run2.2i_dr3
+    matching_method: MATCHING_FORMAT
+include_in_default_catalog_list: true

--- a/GCRCatalogs/dc2_metacal.py
+++ b/GCRCatalogs/dc2_metacal.py
@@ -62,12 +62,15 @@ class DC2MetacalCatalog(DC2DMTractCatalog):
         """
 
         modifiers = {
-            'objectId': 'id',
             'mcal_psf_g1': 'mcal_psf_g1_mean',
             'mcal_psf_g2': 'mcal_psf_g2_mean',
             'mcal_T_psf' : 'mcal_psf_T_mean',
             'mcal_flags' : 'mcal_flags'
         }
+
+        # newer metacal catalogs no longer have the id column
+        if 'id' in self._columns:
+            modifiers['objectId'] = 'id'
 
         # Additional metacal values and their variants
         for variant in ['', '_1p', '_1m', '_2p', '_2m']:

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -758,8 +758,9 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
             modifiers[f'magerr_{band}_cModel'] = (convert_flux_err_to_mag_err,
                                                   f'{band}_modelfit_CModel_{FLUX}',
                                                   f'{band}_modelfit_CModel_{FLUX}{ERR}')
-
-            modifiers['snr_{}_cModel'.format(band)] = '{}_modelfit_SNR'.format(band)
+            modifiers[f'snr_{band}_cModel'] = (np.divide,
+                                               f'{band}_modelfit_CModel_{FLUX}',
+                                               f'{band}_modelfit_CModel_{FLUX}{ERR}')
 
             # Per-band shape information
             modifiers[f'I_flag_{band}'] = f'{band}_base_SdssShape_flag'

--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ Confluence page (*DESC member only*).
 
 
 -  **DC2 "Object Catalogs"** \
-   *by LSST DESC, compiled by Michael Wood-Vasey*
+   *by LSST DESC, compiled by the DC2 Team*
+   - `dc2_object_run2.2i_dr3`: static object catalog for Run 2.2i dr3
+   - `dc2_object_run2.2i_dr3_tract3830`: static object catalog for Run 2.2i dr3 (one tract only, for testing purpose / faster access)
+   - `dc2_object_run2.2i_dr3_with_metacal`: static object catalog for Run 2.2i dr3 + metacal
    - `dc2_object_run2.1i_dr4`: static object catalog for Run 2.1i dr4
    - `dc2_object_run2.1i_dr4_tract3830`: static object catalog for Run 2.1i dr4 (one tract only, for testing purpose / faster access)
    - `dc2_object_run2.1i_dr1b`: static object catalog for Run 2.1i dr1b


### PR DESCRIPTION
fix #418
[edit by @yymao: also fix #389]

I'm not certain about the whether we need a `bands` keyword in the metacal config, this was there in previous version for Run2.1, but I think that was a special case.