### PR TITLE
Refactor register.py

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         pip install pylint
         # stop the build if there are Pylint errors
-        pylint --disable=I,C,R,W0511 --extension-pkg-whitelist=numpy GCRCatalogs
+        pylint --disable=all --enable=F,E,unreachable,duplicate-key,unnecessary-semicolon,global-variable-not-assigned,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode --extension-pkg-whitelist=numpy GCRCatalogs
     - name: Test with pytest
       run: |
         pip install pytest

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -507,21 +507,21 @@ def reset_root_dir():
 
 def get_available_catalogs(
     include_default_only=True,
-    names_only=True,
+    names_only=False,
     name_startswith=None,
     name_contains=None,
     **kwargs
 ):
     """
-    Returns a list of all available catalogs.
+    Returns a dictionary of all available catalogs and their corresponding configs.
 
     Parameters
     ----------
     include_default_only: bool, optional (default: True)
         When set to False, returned list will include catalogs that are not in the default listing
         (i.e., those may not be suitable for general comsumption)
-    names_only: bool, optional (default: True)
-        When set to False, ruturns a dictionary where keys are catalog names and values are corresponding configs.
+    names_only: bool, optional (default: False)
+        When set to True, ruturns just a list of catalog names.
     name_startswith: str, optional (default: None)
         If set, only return catalogs whose name starts with *name_startswith*
     name_contains: str, optional (default: None)

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -9,7 +9,9 @@ import socket
 from GCR import BaseGenericCatalog
 from .utils import is_string_like
 
-__all__ = ["get_root_dir", "set_root_dir", "reset_root_dir", "get_available_catalogs", "get_reader_list", "get_catalog_config", "has_catalog", "load_catalog"]
+__all__ = [
+    "get_root_dir", "set_root_dir", "reset_root_dir", "get_available_catalogs",
+    "get_reader_list", "get_catalog_config", "has_catalog", "load_catalog", "retrieve_paths"]
 
 
 _GITHUB_URL = "https://raw.githubusercontent.com/LSSTDESC/gcr-catalogs/master/GCRCatalogs"
@@ -578,6 +580,25 @@ def load_catalog(catalog_name, config_overwrite=None):
     catalog : instance of a subclass of BaseGalaxyCatalog
     """
     return _config_register[catalog_name].load_catalog(config_overwrite)
+
+
+def retrieve_paths(name_startswith=None, name_contains=None, **kwargs):
+    """
+    Retrieve all paths that are specificed in the configs files.
+
+    Parameters
+    ----------
+    name_startswith: str, optional (default: None)
+        If set, only return catalogs whose name starts with *name_startswith*
+    name_contains: str, optional (default: None)
+        If set, only return catalogs whose name contains with *name_contains*
+
+    Return
+    ------
+    A list of tuples.
+    The format would be [(catalog_name, original_path, resolved_path), ...]
+    """
+    return _config_register.retrieve_paths(name_startswith=name_startswith, name_contains=name_contains, **kwargs)
 
 
 _config_register = ConfigRegister(_CONFIG_DIRPATH, _SITE_CONFIG_PATH)

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -470,10 +470,13 @@ class ConfigRegister(RootDirManager, ConfigManager):
             config.reset_resolved_content()
         RootDirManager.root_dir.__set__(self, path)  # pylint: disable=no-member
 
-    def record_all_paths(self):
+    def retrieve_paths(self, **kwargs):
+        kwargs["names_only"] = False
+        kwargs["content_only"] = False
+        kwargs["resolve_content"] = False
         record = list()
-        for config in self.configs:
-            self.resolve_root_dir(config.content, config.rootname, record)
+        for config_name, config_dict in self.get_configs(**kwargs).items():
+            self.resolve_root_dir(config_dict, config_name, record)
         return record
 
 

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -16,7 +16,7 @@ _GITHUB_URL = "https://raw.githubusercontent.com/LSSTDESC/gcr-catalogs/master/GC
 _HERE = os.path.dirname(__file__)
 _CONFIG_DIRNAME = "catalog_configs"
 _CONFIG_DIRPATH = os.path.join(_HERE, _CONFIG_DIRNAME)
-_SITE_CONFIG_PATH = os.path.join(_HERE, "site_configs", "site_rootdir.yaml")
+_SITE_CONFIG_PATH = os.path.join(_HERE, "site_config", "site_rootdir.yaml")
 
 
 def load_yaml_local(yaml_file):

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -292,7 +292,7 @@ class ConfigManager(Mapping):
         name = str(name).lower()
         for extension in self.YAML_EXTENSIONS:
             if name.endswith(extension):
-                return name[: -len(extension)]
+                return name[:-len(extension)]
         return name
 
     def __getitem__(self, key):
@@ -319,7 +319,7 @@ class ConfigManager(Mapping):
                 if past_refs is None:
                     past_refs = [base_name]
                 elif base_name in past_refs:
-                    raise RecursionError("Recursive reference")
+                    raise RecursionError("Recursive reference (alias or based_on) of `{}`".format(base_name))
                 else:
                     past_refs.append(base_name)
 

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -463,6 +463,8 @@ def get_available_catalogs(include_default_only=True, names_only=False, **kwargs
     If *include_default_only* is set to False, the returned list/dict will
     include catalogs that are not in the default listing.
     """
+    kwargs.setdefault("resolve_content", True)
+    kwargs.setdefault("include_pseudo", False)
     return _config_register.get_configs(
         names_only=names_only, include_default_only=include_default_only, **kwargs
     )

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -162,13 +162,16 @@ class RootDirManager:
         """
         for k, v in config_dict.items():
             if k in self._PATH_LIKE_KEYS and is_string_like(v):
-                if record is not None:
-                    record.append((config_name, v))
-                if v.startswith(self._ROOT_DIR_SIGNAL):
+                orig_path = resolved_path = v
+                if orig_path.startswith(self._ROOT_DIR_SIGNAL):
                     try:
-                        config_dict[k] = os.path.join(self.root_dir, v[len(self._ROOT_DIR_SIGNAL):])
+                        resolved_path = os.path.join(self.root_dir, orig_path[len(self._ROOT_DIR_SIGNAL):])
                     except TypeError:
                         warnings.warn("Root dir has not been set!")
+                    else:
+                        config_dict[k] = resolved_path
+                if record is not None:
+                    record.append((config_name, orig_path, resolved_path))
 
             elif k in self._DICT_LIST_KEYS and isinstance(v, list):
                 for c in v:

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -507,7 +507,7 @@ def load_catalog(catalog_name, config_overwrite=None):
     ------
     catalog : instance of a subclass of BaseGalaxyCatalog
     """
-    _config_register[catalog_name].load_catalog(config_overwrite)
+    return _config_register[catalog_name].load_catalog(config_overwrite)
 
 
 _config_register = ConfigRegister(_CONFIG_DIRPATH, _SITE_CONFIG_PATH)

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -497,20 +497,36 @@ def reset_root_dir():
     _config_register.reset_root_dir()
 
 
-def get_available_catalogs(include_default_only=True, names_only=False, **kwargs):
+def get_available_catalogs(
+    include_default_only=True,
+    names_only=True,
+    name_startswith=None,
+    name_contains=None,
+    **kwargs
+):
     """
-    Returns all available catalogs and their corresponding config files
-    as a dictionary (when *names_only* set to False),
-    or returns available catalog names as a list (when *names_only* set to True).
+    Returns a list of all available catalogs.
 
-    If *include_default_only* is set to False, the returned list/dict will
-    include catalogs that are not in the default listing.
+    Parameters
+    ----------
+    include_default_only: bool, optional (default: True)
+        When set to False, returned list will include catalogs that are not in the default listing
+        (i.e., those may not be suitable for general comsumption)
+    names_only: bool, optional (default: True)
+        When set to False, ruturns a dictionary where keys are catalog names and values are corresponding configs.
+    name_startswith: str, optional (default: None)
+        If set, only return catalogs whose name starts with *name_startswith*
+    name_contains: str, optional (default: None)
+        If set, only return catalogs whose name contains with *name_contains*
     """
-    if not names_only:
-        kwargs.setdefault("resolve_content", True)
-    kwargs.setdefault("include_pseudo", False)
+    if "resolve_content" not in kwargs:
+        kwargs["resolve_content"] = (not names_only)
     return _config_register.get_configs(
-        names_only=names_only, include_default_only=include_default_only, **kwargs
+        names_only=names_only,
+        include_default_only=include_default_only,
+        name_startswith=name_startswith,
+        name_contains=name_contains,
+        **kwargs
     )
 
 

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -329,6 +329,8 @@ class ConfigManager(Mapping):
         include_default_only=False,
         include_pseudo=False,
         include_pseudo_only=False,
+        name_startswith=None,
+        name_contains=None,
         additional_conditions=None,
     ):
         if names_only and content_only:
@@ -362,6 +364,12 @@ class ConfigManager(Mapping):
             conditions.append(lambda config: config.is_pseudo)
         elif not include_pseudo:
             conditions.append(lambda config: not config.is_pseudo)
+        if name_startswith:
+            name_startswith_lower = str(name_startswith).lower()
+            conditions.append(lambda config: config.name.startswith(name_startswith_lower))
+        if name_contains:
+            name_contains_lower = str(name_contains).lower()
+            conditions.append(lambda config: name_contains_lower in config.name)
         if additional_conditions:
             conditions.extend(additional_conditions)
 

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -133,7 +133,7 @@ class RootDirManager:
     def reset_root_dir(self):
         self._custom_root_dir = None
 
-    def resolve_root_dir(self, config_dict, config_name=None):
+    def resolve_root_dir(self, config_dict, config_name=None):  # pylint: disable=unused-argument
         """
         input dictionary `config_dict` will be modified in-place and returned
         """
@@ -153,7 +153,7 @@ class RootDirManager:
 
 
 class Config(Mapping):
-    _YAML_EXTENSIONS = (".yaml", ".yml")
+    YAML_EXTENSIONS = (".yaml", ".yml")
 
     def __init__(self, config_path, config_dir="", resolvers=None):
         self.path = os.path.join(config_dir, config_path)
@@ -176,7 +176,7 @@ class Config(Mapping):
 
     @property
     def ignore(self):
-        return self.rootname.startswith("_") or self.ext.lower() not in self._YAML_EXTENSIONS
+        return self.rootname.startswith("_") or self.ext.lower() not in self.YAML_EXTENSIONS
 
     @property
     def content(self):
@@ -268,7 +268,7 @@ class Config(Mapping):
 
 class ConfigManager(Mapping):
 
-    _YAML_EXTENSIONS = Config._YAML_EXTENSIONS
+    YAML_EXTENSIONS = Config.YAML_EXTENSIONS
 
     def __init__(self, config_dir):
         self._config_dir = config_dir

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -19,6 +19,8 @@ _CONFIG_DIRPATH = os.path.join(_HERE, _CONFIG_DIRNAME)
 _SITE_CONFIG_PATH = os.path.join(_HERE, "site_config", "site_rootdir.yaml")
 
 
+# yaml helper functions
+
 def load_yaml_local(yaml_file):
     """
     Loads a yaml file on disk at path *yaml_file*.
@@ -46,6 +48,8 @@ def load_yaml(yaml_file):
     return config
 
 
+# catalog loading helper functions
+
 def import_subclass(subclass_path, package=None, required_base_class=None):
     """
     Imports and returns a subclass.
@@ -68,6 +72,8 @@ def load_catalog_from_config_dict(catalog_config):
         catalog_config["subclass_name"], __package__, BaseGenericCatalog
     )(**catalog_config)
 
+
+# Classes
 
 class RootDirManager:
     _ROOT_DIR_SIGNAL = "^/"
@@ -280,7 +286,7 @@ class ConfigManager(Mapping):
 
     def normalize_name(self, name):
         name = str(name).lower()
-        for extension in self._YAML_EXTENSIONS:
+        for extension in self.YAML_EXTENSIONS:
             if name.endswith(extension):
                 return name[: -len(extension)]
         return name
@@ -417,6 +423,8 @@ class ConfigRegister(RootDirManager, ConfigManager):
             v.reset_resolved_content()
         RootDirManager.root_dir.__set__(self, path)  # pylint: disable=no-member
 
+
+# module-level functions that access/manipulate _config_register
 
 def get_root_dir():
     """

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -226,9 +226,9 @@ class Config(Mapping):
             if self._resolvers:
                 for resolver in self._resolvers:
                     content = resolver(content, self.name)
-            if self.has_reference:
+            if any(map(content.get, self.REFERENCE_KEYS)):
                 raise ValueError("Fail to resolve references for config `{}`!".format(self.rootname))
-            elif not self.is_valid:
+            elif not (content.get(self.READER_KEY) or self.is_pseudo):
                 raise ValueError("`{}` is missing in config `{}` and its references!".format(self.READER_KEY, self.rootname))
             self._resolved_content_ = content
         return self._resolved_content_

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -463,7 +463,8 @@ def get_available_catalogs(include_default_only=True, names_only=False, **kwargs
     If *include_default_only* is set to False, the returned list/dict will
     include catalogs that are not in the default listing.
     """
-    kwargs.setdefault("resolve_content", True)
+    if not names_only:
+        kwargs.setdefault("resolve_content", True)
     kwargs.setdefault("include_pseudo", False)
     return _config_register.get_configs(
         names_only=names_only, include_default_only=include_default_only, **kwargs

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -9,7 +9,7 @@ import socket
 from GCR import BaseGenericCatalog
 from .utils import is_string_like
 
-__all__ = ["get_root_dir", "set_root_dir", "reset_root_dir", "get_available_catalogs", "has_catalog", "load_catalog"]
+__all__ = ["get_root_dir", "set_root_dir", "reset_root_dir", "get_available_catalogs", "get_reader_list", "get_catalog_config", "has_catalog", "load_catalog"]
 
 
 _GITHUB_URL = "https://raw.githubusercontent.com/LSSTDESC/gcr-catalogs/master/GCRCatalogs"

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -131,9 +131,13 @@ class RootDirManager:
         try:
             os.listdir(path)
         except FileNotFoundError:
-            warnings.warn("root dir has been set to non-existent path '{}'".format(path))
+            warnings.warn("root_dir has been set to non-existent path '{}'".format(path))
         except NotADirectoryError:
-            warnings.warn("root dir has been set to a regular file '{}'; should be directory".format(path))
+            warnings.warn("root_dir has been set to a regular file '{}'; should be directory".format(path))
+        except PermissionError:
+            warnings.warn("root_dir has been set to '{}' but you have no permission to access it".format(path))
+        except OSError as e:
+            warnings.warn("root_dir has been set to '{}' but errors may occur when you try to access it: {}".format(path, e))
         self._custom_root_dir = path
 
     def reset_root_dir(self):

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -160,7 +160,7 @@ class RootDirManager:
             elif k in self._DICT_LIST_KEYS and isinstance(v, list):
                 for c in v:
                     if isinstance(c, dict):
-                        self.resolve_root_dir(c)
+                        self.resolve_root_dir(c, config_name, record)
 
         return config_dict
 

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -201,7 +201,7 @@ class Config(Mapping):
             if self._resolvers:
                 for resolver in self._resolvers:
                     content = resolver(content, self.name)
-            if "subclass_name" not in content:
+            if not self.is_pseudo and "subclass_name" not in content:
                 raise ValueError(
                     "`subclass_name` is missing in the config of {}"
                     "and all of its references".format(self.name)

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -254,7 +254,10 @@ class Config(Mapping):
         if config_overwrite:
             if self._has_reference_keys(config_overwrite):
                 raise ValueError("`config_overwrite` cannot specify `alias` or `based_on`!")
-        return load_catalog_from_config_dict(dict(self._resolved_content, **config_overwrite))
+            config_dict = dict(self._resolved_content, **config_overwrite)
+        else:
+            config_dict = self._resolved_content
+        return load_catalog_from_config_dict(config_dict)
 
     def online_alias_check(self):
         if not self.is_alias:


### PR DESCRIPTION
I refactored `register.py` in this pull request. The motivation is that there are now lots of functions and module variables in `register.py`, but many of them are in fact separable. Hence, a refactor can make future maintenance and feature implementation easier. 

The diff in the PR is not going to be very helpful, so let me outline the new structure here. I suggest reading the new file directly when reviewing. 

During runtime all the configs are stored in a module-level variable `_config_register`, which is an instance of `ConfigRegister`. With the exception of a few helper functions at the beginning, all other module-level functions should be functions that access or manipulate `_config_register`. 

Previously, `root_dir` is stored as a module-level variable, but it really should be a property of `_config_register`, because conceptually, a user can create two instances of `ConfigRegister` that both have the same set of configs but different `root_dir`'s. 

(This is actually the _real_ motivation of this refactoring, as I noticed a bug -- if one loads a catalog, and then sets a new runtime `root_dir`, and then reload the same catalog again, the newly set `root_dir` won't take effect because it was cached. While this is not a common use case, it highlights the inconsistency between the use of module-level variables and object attributes.) 

So the goal is to move everything into object attributes. Instead of just putting all the `root_dir`-related functions into `ConfigRegister`, I put them in a new `RootDirManager` class, which contains all the functionality regarding changing and setting `root_dir`. 

The `ConfigRegister` class is now a mixin of `RootDirManager` and `ConfigManager`, the latter deals with identifying all the config files, and resolve `alias`/`based_on`. 

Individual config is wrapped by the `Config` class like before. But in this refactoring, I make sure that all the single-config-related functions are actually in `Config` (previously some are methods of `Config`, but others are module-level functions). 

For example, if `config` is an instance of `Config`, then it would be ideal if I can simply access `config.resolved_content` to get the resolved dictionary. Originally once has to call `_config_register.get_resolved("catalog_name")` to resolve alias, but to call `_resolve_dict(catalog_dict)` to resolve root dir. This is now homogenized. `ConfigManager` has a `resolve_refernce` method for resolving `alias` and `based_on` and `RootDirManager` has `resolve_root_dir`. Both methods are added to `Config.resolvers` (see around line 418). This way, when one accesses `config.resolved_content` on a single config instance, it knows how to resolve both `alias`/`based_on` and also `root_dir`. 

And, last but not least, this PR adds the concept of a "pseudo" config file. If a `is_pseudo_entry` key exists, then the config does not need to be loadable (i.e., it doesn't need to have `subclass_name`). 

In addition, many more convenient options are added to `get_available_catalogs` (they are passed to `ConfigManager.get_configs`) to help selecting specific sets of config files. 