### PR TITLE
Fix two issues in a recent test run

### DIFF
--- a/GCRCatalogs/dc2_dia_object.py
+++ b/GCRCatalogs/dc2_dia_object.py
@@ -36,8 +36,11 @@ class DC2DiaObjectCatalog(DC2DMTractCatalog):
     FILE_PATTERN = r'dia_object_tract_\d+\.parquet$'
     META_PATH = os.path.join(FILE_DIR, 'catalog_configs/_dc2_dia_object_meta.yaml')
 
+    def _detect_available_bands(self):
+        return [col.partition('_')[2] for col in self._columns if col.startswith('psFluxMean_')]
+
     @staticmethod
-    def _generate_modifiers(dm_schema_version=4, bands='ugrizy'):  # pylint: disable=arguments-differ
+    def _generate_modifiers(dm_schema_version=4, bands='ugrizy', **kwargs):  # pylint: disable=arguments-differ
         """Creates a dictionary relating native and homogenized column names
 
         Args:

--- a/GCRCatalogs/dc2_dia_source.py
+++ b/GCRCatalogs/dc2_dia_source.py
@@ -35,7 +35,7 @@ class DC2DiaSourceCatalog(DC2DMVisitCatalog):
     META_PATH = os.path.join(FILE_DIR, 'catalog_configs/_dc2_dia_source_meta.yaml')
 
     @staticmethod
-    def _generate_modifiers(dm_schema_version=3):
+    def _generate_modifiers(dm_schema_version=3, **kwargs):
         """Creates a dictionary relating native and homogenized column names
 
         Args:

--- a/GCRCatalogs/dc2_forced_source.py
+++ b/GCRCatalogs/dc2_forced_source.py
@@ -33,7 +33,7 @@ class DC2ForcedSourceCatalog(DC2DMVisitCatalog):
     META_PATH = os.path.join(FILE_DIR, 'catalog_configs/_dc2_forced_source_meta.yaml')
 
     @staticmethod
-    def _generate_modifiers(dm_schema_version=3):
+    def _generate_modifiers(dm_schema_version=3, **kwargs):
         """Creates a dictionary relating native and homogenized column names
 
         Args:
@@ -42,9 +42,6 @@ class DC2ForcedSourceCatalog(DC2DMVisitCatalog):
         Returns:
             A dictionary of the form {<homogenized name>: <native name>, ...}
         """
-
-        if dm_schema_version not in (1, 2, 3):
-            raise ValueError('Only supports dm_schema_version == 1, 2, or 3')
 
         flux_name = 'flux' if dm_schema_version <= 2 else 'instFlux'
         flux_err_name = 'Sigma' if dm_schema_version <= 1 else 'Err'

--- a/GCRCatalogs/dc2_matched_table.py
+++ b/GCRCatalogs/dc2_matched_table.py
@@ -122,7 +122,6 @@ class DC2MatchedTable(BaseGenericCatalog):
                 colnames = cols
         return colnames
 
-
     def _generate_native_quantity_list(self):
         return self._column_names
 

--- a/GCRCatalogs/dc2_metacal.py
+++ b/GCRCatalogs/dc2_metacal.py
@@ -38,9 +38,6 @@ class DC2MetacalCatalog(DC2DMTractCatalog):
         """
         Wraps default init method to apply various corrections to the catalog.
         """
-        # Default values of reader parameters
-        self._bands = kwargs.get('bands', 'riz') # default to 'riz' if 'bands' not exist
-
         self._flux_scaling = 1.0
         if kwargs.get('apply_metacal_test3_fix'):
             # In Run 1.2i metacal_test3, the fluxes returned by metacal are not
@@ -50,12 +47,14 @@ class DC2MetacalCatalog(DC2DMTractCatalog):
 
         super(DC2MetacalCatalog, self)._subclass_init(**kwargs)
 
+    def _detect_available_bands(self):
+        return list(set((col.split('_')[3] for col in self._columns if col.startswith('mcal_gauss_flux_'))))
 
-    def _generate_modifiers(self, dm_schema_version=3):
+    def _generate_modifiers(self, bands="riz", **kwargs):
         """Creates a dictionary relating native and homogenized column names
 
         Args:
-            dm_schema_version (int): DM schema version (1, 2, or 3)
+            bands (str or list): list of filter names
 
         Returns:
             A dictionary of the form {<homogenized name>: <native name>, ...}
@@ -64,8 +63,8 @@ class DC2MetacalCatalog(DC2DMTractCatalog):
         modifiers = {
             'mcal_psf_g1': 'mcal_psf_g1_mean',
             'mcal_psf_g2': 'mcal_psf_g2_mean',
-            'mcal_T_psf' : 'mcal_psf_T_mean',
-            'mcal_flags' : 'mcal_flags'
+            'mcal_T_psf':  'mcal_psf_T_mean',
+            'mcal_flags':  'mcal_flags',
         }
 
         # newer metacal catalogs no longer have the id column
@@ -83,7 +82,7 @@ class DC2MetacalCatalog(DC2DMTractCatalog):
             modifiers['mcal_s2n{}'.format(variant)] = 'mcal_gauss_s2n{}'.format(variant)
 
             # Adds band dependent info and their variants
-            for band in self._bands:
+            for band in bands:
                 modifiers['mcal_flux_{}{}'.format(band, variant)] = (
                     lambda x: x * self._flux_scaling,
                     'mcal_gauss_flux_{}{}'.format(band, variant)
@@ -97,7 +96,7 @@ class DC2MetacalCatalog(DC2DMTractCatalog):
                     'mcal_gauss_flux_{}{}'.format(band, variant),
                 )
                 modifiers['mcal_mag_err_{}{}'.format(band, variant)] = (
-                    lambda flux, err: (2.5 * err ) / (flux * np.log(10)),
+                    lambda flux, err: (2.5 * err) / (flux * np.log(10)),
                     'mcal_gauss_flux_{}{}'.format(band, variant),
                     'mcal_gauss_flux_err_{}{}'.format(band, variant),
                 )

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -619,10 +619,10 @@ class DC2ObjectCatalog(BaseGenericCatalog):
     def close_all_file_handles(self):
         """Clear all cached file handles"""
 
-        for fh in self._file_handles.values():
-            fh.close()
-
-        self._file_handles.clear()
+        if isinstance(getattr(self, "_file_handles", None), dict):
+            for fh in self._file_handles.values():
+                fh.close()
+            self._file_handles.clear()
 
     def _generate_native_quantity_list(self):
         """Return a set of native quantity names as strings"""

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -663,23 +663,16 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
 
         self.FILE_PATTERN = r'object_tract_\d+\.parquet$'
         self.META_PATH = META_PATH
+        self._default_pixel_scale = 0.2
+        self.pixel_scale = float(kwargs.get('pixel_scale', self._default_pixel_scale))
 
-        # hack to skip the call of `_generate_modifiers` in the base class
-        # TODO: fix this some day
-        super()._subclass_init(**dict(kwargs, is_dpdd=True))
+        super()._subclass_init(**kwargs)
 
-        self.pixel_scale = float(kwargs.get('pixel_scale', 0.2))
-
-        if kwargs.get('is_dpdd'):
-            self._quantity_modifiers = {col: None for col in self._columns}
-        else:
-            bands = [col.rpartition('_')[0] for col in self._columns if col.endswith('_FLUXMAG0')]
-
-            self._quantity_modifiers = self._generate_modifiers(
-                self.pixel_scale, bands)
+    def _detect_available_bands(self):
+        return [col.rpartition('_')[0] for col in self._columns if col.endswith('_FLUXMAG0')]
 
     @staticmethod
-    def _generate_modifiers(pixel_scale=0.2, bands='ugrizy'):  # pylint: disable=arguments-differ
+    def _generate_modifiers(dm_schema_version=4, bands='ugrizy', pixel_scale=0.2, **kwargs):  # pylint: disable=arguments-differ
         """Creates a dictionary relating native and homogenized column names
 
         Args:
@@ -690,8 +683,8 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
             A dictionary of the form {<homogenized name>: <native name>, ...}
         """
 
-        FLUX = 'instFlux'
-        ERR = 'Err'
+        FLUX = 'flux' if dm_schema_version <= 2 else 'instFlux'
+        ERR = 'Sigma' if dm_schema_version <= 1 else 'Err'
 
         modifiers = {
             'objectId': 'id',

--- a/GCRCatalogs/dc2_photoz_parquet.py
+++ b/GCRCatalogs/dc2_photoz_parquet.py
@@ -38,7 +38,7 @@ class DC2PhotozCatalog(DC2DMTractCatalog):
         'step': 0.01,
         'decimals_to_round': 3,
     }
-    
+
     def _subclass_init(self, **kwargs):
         """
         Wraps default init method to apply various corrections to the catalog.
@@ -51,28 +51,27 @@ class DC2PhotozCatalog(DC2DMTractCatalog):
                                                    self._pdf_bin_info['step'],
         ), self._pdf_bin_info['decimals_to_round'])
         self._n_pdf_bins = len(self._pdf_bin_centers)
-            
+
         super(DC2PhotozCatalog, self)._subclass_init(**kwargs)
 
-
-    def _generate_modifiers(self, dm_schema_version=3):
+    @staticmethod
+    def _generate_modifiers(**kwargs):
         """Creates a dictionary relating native and homogenized column names
-
-        Args:
-            dm_schema_version (int): DM schema version (1, 2, or 3)
 
         Returns:
             A dictionary of the form {<homogenized name>: <native name>, ...}
         """
 
-        modifiers = {'photoz_ODDS':'ODDS',
-                     'photoz_mode':'z_mode',
-                     'photoz_median':'z_median',
-                     'photoz_mean':'z_mean',
-                     'photoz_pdf':'pdf',
-                     'ID':'galaxy_id',
-                     'photoz_mode_ml':'z_mode_ml',
-                     'photoz_mode_ml_red_chi2':'z_mode_ml_red_chi2'}
+        modifiers = {
+            'photoz_ODDS': 'ODDS',
+            'photoz_mode': 'z_mode',
+            'photoz_median': 'z_median',
+            'photoz_mean': 'z_mean',
+            'photoz_pdf': 'pdf',
+            'ID': 'galaxy_id',
+            'photoz_mode_ml': 'z_mode_ml',
+            'photoz_mode_ml_red_chi2': 'z_mode_ml_red_chi2',
+        }
         return modifiers
 
     @property
@@ -82,4 +81,3 @@ class DC2PhotozCatalog(DC2DMTractCatalog):
     @property
     def n_pdf_bins(self):
         return self._n_pdf_bins
-    

--- a/GCRCatalogs/dc2_source.py
+++ b/GCRCatalogs/dc2_source.py
@@ -36,7 +36,7 @@ class DC2SourceCatalog(DC2DMVisitCatalog):
     META_PATH = os.path.join(FILE_DIR, 'catalog_configs/_dc2_source_meta.yaml')
 
     @staticmethod
-    def _generate_modifiers(dm_schema_version=3):
+    def _generate_modifiers(dm_schema_version=3, **kwargs):
         """Creates a dictionary relating native and homogenized column names
 
         Args:
@@ -45,9 +45,6 @@ class DC2SourceCatalog(DC2DMVisitCatalog):
         Returns:
             A dictionary of the form {<homogenized name>: <native name>, ...}
         """
-
-        if dm_schema_version not in (1, 2, 3):
-            raise ValueError('Only supports dm_schema_version == 1, 2, or 3')
 
         flux_name = 'flux' if dm_schema_version <= 2 else 'instFlux'
         flux_err_name = 'Sigma' if dm_schema_version <= 1 else 'Err'


### PR DESCRIPTION
This PR fixes two issues that @JoanneBogart noticed after running the test:

   1. Missing filter warnings. This is due to a non-ideal implementation of `_generate_modifiers`. I use this opportunity to make the implementation more robust. In particular, a new `_detect_available_bands` method is now implemented for several catalogs to automatically detect available filter names.

   2. AttributeError during `DC2ObjectCatalog` cleanup. This PR adds a guard to skip the cleanup if it's already done.