### PR TITLE
More bug fixes to legacy catalogs

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_instance_example1.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_instance_example1.yaml
@@ -1,5 +1,5 @@
 #  Use ^/ to indicate file path relative to GCR root dir
 
 subclass_name: instance_catalog.InstanceCatalog
-header_file: ^/DC2-prod/Run1.1/instance/phosim_cat_2145656.txt
+header_file: ^/DC2-prod/Run1.1/instance_example/phosim_cat_2145656.txt
 description: Example Instance Catalogs for DC2

--- a/GCRCatalogs/catalog_configs/dc2_instance_example2.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_instance_example2.yaml
@@ -1,5 +1,5 @@
 #  Use ^/ to indicate file path relative to GCR root dir
 
 subclass_name: instance_catalog.InstanceCatalog
-header_file: ^/DC2-prod/Run1.2/instance/phosim_cat_2443890.txt
+header_file: ^/DC2-prod/Run1.1/instance_example/phosim_cat_2443890.txt
 description: Example Instance Catalogs for DC2

--- a/GCRCatalogs/catalog_configs/hsc-pdr1-xmm.yaml
+++ b/GCRCatalogs/catalog_configs/hsc-pdr1-xmm.yaml
@@ -1,8 +1,0 @@
-#  Use ^/ to indicate file path relative to GCR root dir
-
-subclass_name: dc2_object.DC2ObjectCatalog
-base_dir: ^/external/hsc/pdr1
-description: XMM field of the HSC PDR1
-creators: ['Hyper Suprime-Cam (HSC) collaboration']
-pixel_scale: 0.168
-include_in_default_catalog_list: true

--- a/GCRCatalogs/dc2_dia_object.py
+++ b/GCRCatalogs/dc2_dia_object.py
@@ -105,8 +105,8 @@ class DC2DiaObjectCatalog(DC2DMTractCatalog):
             modifiers[f'magMean_{band}'] = (convert_nanoJansky_to_mag,
                                             f'psFluxMean_{band}')
             modifiers[f'magMeanErr_{band}'] = (convert_flux_err_to_mag_err,
-                                               'psFluxMean_{band}',
-                                               'psFluxMeanErr_{band}')
+                                               f'psFluxMean_{band}',
+                                               f'psFluxMeanErr_{band}')
             modifiers[f'magMeanStd_{band}'] = (convert_flux_err_to_mag_err,
                                                f'psFluxMean_{band}',
                                                f'psFluxSigma_{band}')

--- a/GCRCatalogs/dc2_dia_object.py
+++ b/GCRCatalogs/dc2_dia_object.py
@@ -70,26 +70,26 @@ class DC2DiaObjectCatalog(DC2DMTractCatalog):
             'diaObjectId': 'diaObjectId',
             'ra': (np.rad2deg, 'coord_ra'),
             'dec': (np.rad2deg, 'coord_dec'),
-#            'radecCov':  # A covariance matrix for the uncertainty in ra, dec
-#            'radecTai': 'dateobs'?  # I don't know what this is called
-#            'pm':
-#            'pmParallaxCov':
-#            'pmParallaxLnl':
-#            'pmParallaxChi2':
-#            'pmParallaxNdata':
-#            'totFluxMean': 'ip_diffim_forced_PsfFlux_instFlux',
-#            'totFluxMeanErr': 'ip_diffim_forced_PsfFlux_instFluxErr',
-#            'totFluxSigma': 'ip_diffim_forced_PsfFlux_instFluxErr',
-#            'lcPeriodic'
-#            'lcNonPeriodic'
-#  These are possible to calculate if you require the Object Table
-#            'nearbyObj':
-#            'nearbyObjDist':
-#            'nearbyObjLnP':
+            # 'radecCov': '',  # A covariance matrix for the uncertainty in ra, dec
+            # 'radecTai': 'dateobs',  # I don't know what this is called
+            # 'pm': '',
+            # 'pmParallaxCov': '',
+            # 'pmParallaxLnl': '',
+            # 'pmParallaxChi2': '',
+            # 'pmParallaxNdata': '',
+            # 'totFluxMean': 'ip_diffim_forced_PsfFlux_instFlux',
+            # 'totFluxMeanErr': 'ip_diffim_forced_PsfFlux_instFluxErr',
+            # 'totFluxSigma': 'ip_diffim_forced_PsfFlux_instFluxErr',
+            # 'lcPeriodic': '',
+            # 'lcNonPeriodic': '',
+            # # These are possible to calculate if you require the Object Table
+            # 'nearbyObj': '',
+            # 'nearbyObjDist': '',
+            # 'nearbyObjLnP': '',
         }
 
-        modifiers['good'] = (create_basic_flag_mask,)
-        modifiers['clean'] = modifiers['good']
+        # modifiers['good'] = (create_basic_flag_mask, )
+        # modifiers['clean'] = modifiers['good']
 
         multiband_columns_to_copy = [
             'psFluxMean', 'psFluxMeanErr',
@@ -100,8 +100,7 @@ class DC2DiaObjectCatalog(DC2DMTractCatalog):
                 col_name = f'{base_col}_{band}'
                 modifiers[col_name] = col_name
 
-        # Create new convenience magnitude columns based on flux values
-        for band in bands:
+            # Create new convenience magnitude columns based on flux values
             modifiers[f'magMean_{band}'] = (convert_nanoJansky_to_mag,
                                             f'psFluxMean_{band}')
             modifiers[f'magMeanErr_{band}'] = (convert_flux_err_to_mag_err,

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -290,7 +290,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
             # and just rely on that versioning.
             has_modelfit_mag = any(col.endswith('_modelfit_mag') for col in self._schema)
             has_modelfit_flux = any('_modelfit_CModel_' in col for col in self._schema)
-            has_modelfit_flag = any(col.endswith('_modelfit_CModel_flag') in col for col in self._schema)
+            has_modelfit_flag = any(col.endswith('_modelfit_CModel_flag') for col in self._schema)
 
             if not (has_modelfit_mag or has_modelfit_flux):
                 warnings.warn("No modelfit infomation is available in the columns.")

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -289,6 +289,9 @@ class DC2ObjectCatalog(BaseGenericCatalog):
             # A future improvement will be to explicitly store version information in the datasets
             # and just rely on that versioning.
             has_modelfit_mag = any(col.endswith('_modelfit_mag') for col in self._schema)
+            has_modelfit_flux = any('_modelfit_CModel_' in col for col in self._schema)
+            if not (has_modelfit_mag or has_modelfit_flux):
+                warnings.warn("No modelfit infomation is available in the columns.")
 
             if any(col.endswith('_fluxSigma') for col in self._schema):
                 dm_schema_version = 1
@@ -302,7 +305,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
             bands = [col[0] for col in self._schema if len(col) == 5 and col.endswith('_mag')]
 
             self._quantity_modifiers = self._generate_modifiers(
-                self.pixel_scale, bands, has_modelfit_mag, dm_schema_version)
+                self.pixel_scale, bands, has_modelfit_mag, has_modelfit_flux, dm_schema_version)
 
         self._quantity_info_dict = self._generate_info_dict(META_PATH, bands)
         self._len = None
@@ -312,7 +315,7 @@ class DC2ObjectCatalog(BaseGenericCatalog):
 
     @staticmethod
     def _generate_modifiers(pixel_scale=0.2, bands='ugrizy',
-                            has_modelfit_mag=True, dm_schema_version=4):
+                            has_modelfit_mag=True, has_modelfit_flux=True, dm_schema_version=4):
         """Creates a dictionary relating native and homogenized column names
 
         Args:
@@ -380,12 +383,6 @@ class DC2ObjectCatalog(BaseGenericCatalog):
 
             modifiers['I_flag_{}'.format(band)] = '{}_base_SdssShape_flag'.format(band)
 
-            modifiers['cModelFlux_{}'.format(band)] = (convert_dm_ref_zp_flux_to_nanoJansky,
-                                                       '{}_modelfit_CModel_{}'.format(band, FLUX))
-            modifiers['cModelFluxErr_{}'.format(band)] = (convert_dm_ref_zp_flux_to_nanoJansky,
-                                                          '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR))
-            modifiers['cModelFlux_flag_{}'.format(band)] = '{}_modelfit_CModel_flag'.format(band)
-
             for ax in ['xx', 'yy', 'xy']:
                 modifiers['I{}_{}'.format(ax, band)] = '{}_base_SdssShape_{}'.format(band, ax)
                 modifiers['I{}PSF_{}'.format(ax, band)] = '{}_base_SdssShape_psf_{}'.format(band, ax)
@@ -397,23 +394,31 @@ class DC2ObjectCatalog(BaseGenericCatalog):
                 '{}_base_SdssShape_psf_xy'.format(band),
             )
 
-            modifiers['mag_{}_cModel'.format(band)] = '{}_modelfit_mag'.format(band)
-            modifiers['magerr_{}_cModel'.format(band)] = '{}_modelfit_mag_err'.format(band)
-            modifiers['snr_{}_cModel'.format(band)] = '{}_modelfit_SNR'.format(band)
-
-            if not has_modelfit_mag:
+            if has_modelfit_flux:
                 # The zp=27.0 is based on the default calibration for the coadds
                 # as specified in the DM code.  It's correct for Run 1.1p.
-                modifiers['mag_{}_cModel'.format(band)] = (convert_dm_ref_zp_flux_to_mag,
+                modifiers['cModelFlux_{}'.format(band)] = (convert_dm_ref_zp_flux_to_nanoJansky,
                                                            '{}_modelfit_CModel_{}'.format(band, FLUX))
-                modifiers['magerr_{}_cModel'.format(band)] = (convert_flux_err_to_mag_err,
-                                                              '{}_modelfit_CModel_{}'.format(band, FLUX),
+                modifiers['cModelFluxErr_{}'.format(band)] = (convert_dm_ref_zp_flux_to_nanoJansky,
                                                               '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR))
-                modifiers['snr_{}_cModel'.format(band)] = (
-                    np.divide,
-                    '{}_modelfit_CModel_{}'.format(band, FLUX),
-                    '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR),
-                )
+                modifiers['cModelFlux_flag_{}'.format(band)] = '{}_modelfit_CModel_flag'.format(band)
+
+                if not has_modelfit_mag:
+                    modifiers['mag_{}_cModel'.format(band)] = (convert_dm_ref_zp_flux_to_mag,
+                                                               '{}_modelfit_CModel_{}'.format(band, FLUX))
+                    modifiers['magerr_{}_cModel'.format(band)] = (convert_flux_err_to_mag_err,
+                                                                  '{}_modelfit_CModel_{}'.format(band, FLUX),
+                                                                  '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR))
+                    modifiers['snr_{}_cModel'.format(band)] = (
+                        np.divide,
+                        '{}_modelfit_CModel_{}'.format(band, FLUX),
+                        '{}_modelfit_CModel_{}{}'.format(band, FLUX, ERR),
+                    )
+
+            if has_modelfit_mag:
+                modifiers['mag_{}_cModel'.format(band)] = '{}_modelfit_mag'.format(band)
+                modifiers['magerr_{}_cModel'.format(band)] = '{}_modelfit_mag_err'.format(band)
+                modifiers['snr_{}_cModel'.format(band)] = '{}_modelfit_SNR'.format(band)
 
         return modifiers
 

--- a/GCRCatalogs/instance_catalog.py
+++ b/GCRCatalogs/instance_catalog.py
@@ -266,7 +266,7 @@ class InstanceCatalog(BaseGenericCatalog):
         return native_quantities
 
     def _pd_read_table(self, obj_type, **kwargs):
-        return pd.read_table(
+        return pd.read_csv(
             self._object_files[obj_type],
             delim_whitespace=True,
             names=[c[0] for c in self._col_names[obj_type]],

--- a/GCRCatalogs/version.py
+++ b/GCRCatalogs/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.16.1'
+__version__ = '0.17.0-alpha'

--- a/README.md
+++ b/README.md
@@ -116,10 +116,6 @@ Confluence page (*DESC member only*).
    - `dc2_instance_example1`: an example instance catalog
    - `dc2_instance_example2`: another example instance catalog
 
--  **HSC Coadd Catalog for PDR1 XMM field** \
-   *by the Hyper Suprime-Cam (HSC) Collaboration*
-   - `hsc-pdr1-xmm`
-
 -  **DC2 e-images** \
    *by LSST DESC*
    - `dc2_eimages_run1.2i_visit-181898`: one visit of e-images for Run 1.2i


### PR DESCRIPTION
This PR contains a few more bug fixes to legacy catalogs:

 1. Remove `hsc-pdr1-xmm` since the files have been purged.
 2. Comment out unfinished modifiers in `dc2_dia_object.py` and fix a f-string bug.
 3. Check the availability of modelfit flux and flag in legacy object catalog.  
 4. Update path to instance catalog examples and fix a deprecation warning.