### PR TITLE
Warn only if site from env differs from socket

### DIFF
--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -128,7 +128,7 @@ class RootDirManager:
         """
         site_from_env = os.getenv(self._DESC_SITE_ENV)
         site_from_socket = socket.getfqdn()
-        if site_from_env and site_from_env not in site_from_socket:
+        if site_from_env and site_from_socket and site_from_env not in site_from_socket:
             warnings.warn("Site determined from env variable {} = {}".format(self._DESC_SITE_ENV, site_from_env))
             return site_from_env
         return site_from_socket

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -128,8 +128,13 @@ class RootDirManager:
         """
         site_from_env = os.getenv(self._DESC_SITE_ENV)
         site_from_socket = socket.getfqdn()
-        if site_from_env and site_from_socket and site_from_env not in site_from_socket:
-            warnings.warn("Site determined from env variable {} = {}".format(self._DESC_SITE_ENV, site_from_env))
+        if site_from_env:
+            if site_from_socket and site_from_env not in site_from_socket and not (
+                site_from_env == "nersc" and site_from_socket.startswith("nid")
+            ):
+                warnings.warn("Site determined from env variable {} = {}, which differs from node name {}".format(
+                    self._DESC_SITE_ENV, site_from_env, site_from_socket
+                ))
             return site_from_env
         return site_from_socket
 

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -126,12 +126,12 @@ class RootDirManager:
         Return a string which, when executing at a recognized site with
         well-known name, will include the name for that site
         """
-        # First look for custom env variable
-        v = os.getenv(self._DESC_SITE_ENV)
-        if v:
-            warnings.warn("Site determined from env variable {}".format(self._DESC_SITE_ENV))
-            return v
-        return socket.getfqdn()
+        site_from_env = os.getenv(self._DESC_SITE_ENV)
+        site_from_socket = socket.getfqdn()
+        if site_from_env and site_from_env not in site_from_socket:
+            warnings.warn("Site determined from env variable {} = {}".format(self._DESC_SITE_ENV, site_from_env))
+            return site_from_env
+        return site_from_socket
 
     @property
     def root_dir(self):


### PR DESCRIPTION
I am asking Heather to set the environment variable `DESC_GCR_SITE` in our python environments on NERSC (https://github.com/LSSTDESC/desc-python/issues/39). I then realize that this would cause a warning to be always printed out. 

This PR is to make it only warn if the site name from DESC_GCR_SITE is inconsistent with the site name from socket. 