### PR TITLE
Deprecate Run 2.1

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1.1i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1.1i.yaml
@@ -6,5 +6,4 @@ filename_pattern: 'object_tract_\d+\.parquet$'
 description: DC2 Run 2.1.1i Object Table
 creators: ['DESC DC2 Team']
 pixel_scale: 0.2
-include_in_default_catalog_list: true
 deprecated: Use dc2_object_run2.2i instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i _tract3830.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i _tract3830.yaml
@@ -1,2 +1,2 @@
 alias: dc2_object_run2.1i_dr4_tract3830
-include_in_default_catalog_list: true
+deprecated: Use dc2_object_run2.2i_tract3830 instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i.yaml
@@ -1,2 +1,2 @@
 alias: dc2_object_run2.1i_dr4
-include_in_default_catalog_list: true
+deprecated: Use dc2_object_run2.2i instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1.yaml
@@ -1,2 +1,2 @@
 alias: dc2_object_run2.1i_dr1b
-deprecated: Use dc2_object_run2.1i or dc2_object_run2.2i instead.
+deprecated: Use dc2_object_run2.2i instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1_tract3830.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1_tract3830.yaml
@@ -1,3 +1,3 @@
 based_on: dc2_object_run2.1i_dr1b
 tract: 3830
-deprecated: Use dc2_object_run2.1i_tract3830 or dc2_object_run2.2i_tract3830 instead.
+deprecated: Use dc2_object_run2.2i_tract3830 instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1a.yaml
@@ -6,4 +6,4 @@ filename_pattern: 'object_tract_\d+\.parquet$'
 description: DC2 Run 2.1i DR1a Object Table
 creators: ['DESC DC2 Team']
 pixel_scale: 0.2
-deprecated: Use dc2_object_run2.1i or dc2_object_run2.2i instead.
+deprecated: Use dc2_object_run2.2i instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b.yaml
@@ -6,4 +6,4 @@ filename_pattern: 'object_tract_\d+\.parquet$'
 description: DC2 Run 2.1i DR1b Object Table
 creators: ['DESC DC2 Team']
 pixel_scale: 0.2
-deprecated: Use dc2_object_run2.1i or dc2_object_run2.2i instead.
+deprecated: Use dc2_object_run2.2i instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4.yaml
@@ -6,3 +6,4 @@ filename_pattern: 'object_tract_\d+\.parquet$'
 description: DC2 Run 2.1i DR1b Object Table
 creators: ['DESC DC2 Team']
 pixel_scale: 0.2
+deprecated: Use dc2_object_run2.2i instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4_tract3830.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr4_tract3830.yaml
@@ -1,2 +1,3 @@
 based_on: dc2_object_run2.1i_dr4
 tract: 3830
+deprecated: Use dc2_object_run2.2i_tract3830 instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_tract3830.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_tract3830.yaml
@@ -1,2 +1,2 @@
 alias: dc2_object_run2.1i_dr4_tract3830
-include_in_default_catalog_list: true
+deprecated: Use dc2_object_run2.2i_tract3830 instead.

--- a/README.md
+++ b/README.md
@@ -67,12 +67,10 @@ Confluence page (*DESC member only*).
 
 -  **DC2 "Object Catalogs"** \
    *by LSST DESC, compiled by the DC2 Team*
-   - `dc2_object_run2.2i`: static object catalog for Run 2.2i (current version = DR3)
+   - `dc2_object_run2.2i`: static object catalog for Run 2.2i (current data release = DR3)
    - `dc2_object_run2.2i_tract3830`: same as `dc2_object_run2.2i` but with one tract only, for testing purpose / faster access
    - `dc2_object_run2.2i_with_metacal`: `dc2_object_run2.2i` + metacal
    - `dc2_object_run2.2i_with_photoz`: `dc2_object_run2.2i` + photo-z
-   - `dc2_object_run2.1i`: static object catalog for Run 2.1i (current version = DR4)
-   - `dc2_object_run2.1i_tract3830`: same as `dc2_object_run2.2i` but with one tract only, for testing purpose / faster access
    - `dc2_object_run1.2i`: static object catalog for Run 1.2i (with only DPDD columns and native columns needed for the DPDD columns)
    - `dc2_object_run1.2i_with_photoz`: same as `dc2_object_run1.2i` but with photo-z's (columns that start with `photoz_`). Photo-z provided by Sam Schmidt.
    - `dc2_object_run1.2i_all_columns`: static object catalog for Run 1.2i (with DPDD and all native columns, slower to access)


### PR DESCRIPTION
Based on our recent discussion in #desc-dc2-data-access, this PR marks Run 2.1 catalogs in GCRCatalogs deprecated. All the marked catalogs will still be accessible in the foreseeable future, but won't be listed in the default catalog lists. 