### PR TITLE
Add redmapper 0.5.7 catalog for cosmodc2 1.1.4

### DIFF
--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_redmapper_v0.2.1py.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_redmapper_v0.2.1py.yaml
@@ -21,4 +21,6 @@ description: |
   Cluster and member catalogs computed from the redMaPPer cluster finder
   (v0.2.1py) run on cosmoDC2 v1.1.4.
 
-include_in_default_catalog_list: true
+deprecated: Use cosmoDC2_v1.1.7_redmapper_v0.5.7 instead
+
+include_in_default_catalog_list: false

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_redmapper_v0.5.7.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_redmapper_v0.5.7.yaml
@@ -1,0 +1,24 @@
+#  Use ^/ to indicate file path relative to GCR root dir
+
+subclass_name: redmapper.RedmapperCatalog
+
+catalog_root_dir: ^/xgal/cosmoDC2/addons/redmapper_v1.1.4
+catalog_path_template:
+  clusters: cosmoDC2_v1.1.4_run_redmapper_v0.5.7_lgt20_catalog.fit
+  members: cosmoDC2_v1.1.4_run_redmapper_v0.5.7_lgt20_catalog_members.fit
+
+sky_area: 439.78987
+
+cosmology:
+  H0: 71.0
+  Om0: 0.2648
+  Ob0: 0.0448
+  sigma8: 0.8
+  n_s: 0.963
+
+creators: ['Eli Rykoff']
+description: |
+  Cluster and member catalogs computed from the redMaPPer cluster finder
+  (v0.5.7) run on cosmoDC2 v1.1.4.
+
+include_in_default_catalog_list: true

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Confluence page (*DESC member only*).
    *by Andrew Benson, Andrew Hearin, Katrin Heitmann, Danila Korytov, Eve Kovacs, Patricia Larsen, Eli Rykoff et al.*
    - `cosmoDC2_v1.1.4_image`: latest cosmoDC2 catalog (used for Run 2.1+)
    - `cosmoDC2_v1.1.4_small`: 17 contiguous healpixels of `cosmoDC2_v1.1.4_image` for testing purpose
-   - `cosmoDC2_v1.1.4_redmapper_v0.2.1py`: Redmapper catalog (v0.2.1) for `cosmoDC2_v1.1.4_image`.
+   - `cosmoDC2_v1.1.4_redmapper_v0.5.7`: Redmapper catalog (v0.5.7) for `cosmoDC2_v1.1.4_image`.
    - `cosmoDC2_v1.1.4_image_with_photozs_v1` and `cosmoDC2_v1.1.4_small_with_photozs_v1`: containing photo-z for cosmoDC2 v1.1.4 (provided by Sam Schmidt)
    - `cosmoDC2_v1.1.4_image_with_photoz_calib` and `cosmoDC2_v1.1.4_small_with_photoz_calib`: containing columns that identify DESI-like QSOs, LRGs, ELGs, or a magnitude limited sample in cosmoDC2 v1.1.4 (provided by Chris Morrison)
 


### PR DESCRIPTION
At long last, I am putting the redMaPPer 0.5.7 catalog from cosmodc2 1.1.4 in gcr-catalogs.  Many apologies for the delay.

I also need to have the catalogs copied into the proper directory.  The files in `/global/cscratch1/sd/erykoff/redmapper_staging` need to be copied to `/global/cfs/cdirs/lsst/shared/xgal/cosmoDC2/addons/redmapper_v1.1.4` before this can be tested and merged.
