### PR TITLE
Add back some old photoz configs for backward compatibility

### DIFF
--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image_photoz_calib.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image_photoz_calib.yaml
@@ -1,0 +1,3 @@
+# TODO: remove this config during next major update
+alias: cosmoDC2_v1.1.4_image_with_photoz_calib
+deprecated: This catalog has been renamed as `cosmoDC2_v1.1.4_image_with_photoz_calib`; use the new catalog name instead.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image_photoz_magerr_10y.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image_photoz_magerr_10y.yaml
@@ -1,0 +1,3 @@
+# TODO: remove this config during next major update
+alias: cosmoDC2_v1.1.4_image_with_photozs_v1
+deprecated: This catalog has been renamed as `cosmoDC2_v1.1.4_image_with_photozs_v1`; use the new catalog name instead.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_photoz_calib.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_photoz_calib.yaml
@@ -1,0 +1,3 @@
+# TODO: remove this config during next major update
+alias: cosmoDC2_v1.1.4_small_with_photoz_calib
+deprecated: This catalog has been renamed as `cosmoDC2_v1.1.4_small_with_photoz_calib`; use the new catalog name instead.

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_photoz_magerr_10y.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_photoz_magerr_10y.yaml
@@ -1,0 +1,3 @@
+# TODO: remove this config during next major update
+alias: cosmoDC2_v1.1.4_small_with_photozs_v1
+deprecated: This catalog has been renamed as `cosmoDC2_v1.1.4_small_with_photozs_v1`; use the new catalog name instead.


### PR DESCRIPTION
I am about to make a new release of GCRCatalogs (v0.18.0), and as part of the process I am evaluate all the backward incompatibile changes. 

I think we might want to maintain backward compatibility for some of the renamed photoz configs. I am looking at [this useful confluence page](https://confluence.slac.stanford.edu/display/LSSTDESC/List+of+available+DC2+catalogs+created+by+PhotoZ) that you made, and propose to add back in

- `cosmoDC2_v1.1.4_image_photoz_calib`
- `cosmoDC2_v1.1.4_image_photoz_magerr_10y`
- `cosmoDC2_v1.1.4_small_photoz_calib`
- `cosmoDC2_v1.1.4_small_photoz_magerr_10y`

Each of these is an alias to the new config and a deprecation warning will be printed out when user uses the old name, but their code will still run. 

One question I have is whether we need to do the same for the following two?

- `cosmoDC2_v1.1.4_image_photoz_magerr_10y_PDFcat`
- `photoz_magerr_10y_estimate_image`

I was thinking that few people probably have used these two so it'd be ok to break backward compatibility. But let me know if you think otherwise.