### PR TITLE
Remove ambiguous Run 2.1i configs

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i _tract3830.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i _tract3830.yaml
@@ -1,2 +1,0 @@
-alias: dc2_object_run2.1i_dr4_tract3830
-deprecated: Use dc2_object_run2.2i_dr6_tract3830 instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i.yaml
@@ -1,2 +1,0 @@
-alias: dc2_object_run2.1i_dr4
-deprecated: Use dc2_object_run2.2i_dr6 instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_tract3830.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_tract3830.yaml
@@ -1,2 +1,0 @@
-alias: dc2_object_run2.1i_dr4_tract3830
-deprecated: Use dc2_object_run2.2i_dr6_tract3830 instead.


### PR DESCRIPTION
As discussed in #456, I am removing Run 2.x config that do not have a clear DR designation. I tried to avoid breaking backward compatibility, but when preparing the new release, I noticed these three configs are added after v0.17.0, so they all can be removed without breaking backward compatibility (and one of them even has a typo in the catalog name :sweat_smile:). 