### PR TITLE
Correct the definition of psf_fwhm to be for model PSF.

### DIFF
--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -773,8 +773,8 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
 
             modifiers[f'psf_fwhm_{band}'] = (
                 lambda xx, yy, xy: pixel_scale * 2.355 * (xx * yy - xy * xy) ** 0.25,
-                f'{band}_base_SdssShape_xx',
-                f'{band}_base_SdssShape_yy',
-                f'{band}_base_SdssShape_xy')
+                f'{band}_base_SdssShape_psf_xx',
+                f'{band}_base_SdssShape_psf_yy',
+                f'{band}_base_SdssShape_psf_xy')
 
         return modifiers


### PR DESCRIPTION
Simple fix.  Tested on Cori with local installation of `gcr-catalogs`.

Fixes my error from last fall 2019.  

fix #460 