### PR TITLE
Issue/465/dc2pzcatalogfix

### DIFF
--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image_with_photozs_v1.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image_with_photozs_v1.yaml
@@ -14,8 +14,8 @@ description: |
      Data used for training BPZ is representative down to scatmag_i < 25.
 catalogs:
   - catalog_name: cosmoDC2_v1.1.4_image
-    matching_method: galaxy_id
+    matching_method: MATCHING_FORMAT
   - catalog_name: photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image
     matching_method: MATCHING_FORMAT
   - catalog_name: photoz_pdfs_v1_for_cosmoDC2_v1.1.4_image
-    matching_method: galaxy_id
+    matching_method: MATCHING_FORMAT

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_with_photozs_v1.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_with_photozs_v1.yaml
@@ -1,10 +1,10 @@
 based_on: cosmoDC2_v1.1.4_image_with_photozs_v1
 catalogs:
   - catalog_name: cosmoDC2_v1.1.4_small
-    matching_method: galaxy_id
+    matching_method: MATCHING_FORMAT
   - catalog_name: photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image
     healpix_pixels: [9559, 9686, 9687, 9814, 9815, 9816, 9942, 9943, 10070, 10071, 10072, 10198, 10199, 10200, 10326, 10327, 10450]
     matching_method: MATCHING_FORMAT
   - catalog_name: photoz_pdfs_v1_for_cosmoDC2_v1.1.4_image
     healpix_pixels: [9559, 9686, 9687, 9814, 9815, 9816, 9942, 9943, 10070, 10071, 10072, 10198, 10199, 10200, 10326, 10327, 10450]
-    matching_method: galaxy_id
+    matching_method: MATCHING_FORMAT

--- a/GCRCatalogs/catalog_configs/photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image.yaml
+++ b/GCRCatalogs/catalog_configs/photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image.yaml
@@ -3,7 +3,6 @@
 subclass_name: photoz_magerr.PZMagErrCatalog
 catalog_name: photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image
 base_dir: ^/xgal/cosmoDC2/addons/photoz_v1.1.4/IMAGE/10_year_error_estimates
-filename_pattern: 'z_(\d)\S+withmask.healpix_(\d+)_magwerr\.h5'
 creators: ['Sam Schmidt']
 description:
      This is a catalog of CosmoDC2v1.1.4_image extragalactic truth objects with estimated 10 year depth flux errors estimated from the model of Ivezic et al. 2019 included.  Flux errors are computed given the expected number of 10-year depth visits, Gaussian uncertainties are added to the true fluxes and converted back to magnitudes.  For negative fluxes resulting from this procedure, a magnitude of "99" is reported, and the error column stores the 1-sigma point source magnitude for an object at the given depth.

--- a/GCRCatalogs/catalog_configs/photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image.yaml
+++ b/GCRCatalogs/catalog_configs/photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image.yaml
@@ -2,7 +2,8 @@
 
 subclass_name: photoz_magerr.PZMagErrCatalog
 catalog_name: photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image
-base_dir: ^/xgal/cosmoDC2/addons/photoz_v1.1.4/IMAGE/10_year_error_estimates
+base_dir: /global/cfs/cdirs/lsst/groups/PZ/PhotoZDC2/COSMODC2v1.1.4/IMAGE/10_year_error_estimates
+filename_pattern: 'z_(\d)\S+withmask.healpix_(\d+)_magwerr\.h5'
 creators: ['Sam Schmidt']
 description:
      This is a catalog of CosmoDC2v1.1.4_image extragalactic truth objects with estimated 10 year depth flux errors estimated from the model of Ivezic et al. 2019 included.  Flux errors are computed given the expected number of 10-year depth visits, Gaussian uncertainties are added to the true fluxes and converted back to magnitudes.  For negative fluxes resulting from this procedure, a magnitude of "99" is reported, and the error column stores the 1-sigma point source magnitude for an object at the given depth.

--- a/GCRCatalogs/catalog_configs/photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image.yaml
+++ b/GCRCatalogs/catalog_configs/photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image.yaml
@@ -2,7 +2,7 @@
 
 subclass_name: photoz_magerr.PZMagErrCatalog
 catalog_name: photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image
-base_dir: /global/cfs/cdirs/lsst/groups/PZ/PhotoZDC2/COSMODC2v1.1.4/IMAGE/10_year_error_estimates
+base_dir: ^/xgal/cosmoDC2/addons/photoz_v1.1.4/IMAGE/10_year_error_estimates
 filename_pattern: 'z_(\d)\S+withmask.healpix_(\d+)_magwerr\.h5'
 creators: ['Sam Schmidt']
 description:

--- a/GCRCatalogs/photoz_magerr.py
+++ b/GCRCatalogs/photoz_magerr.py
@@ -17,7 +17,7 @@ from .utils import first
 
 __all__ = ['PZMagErrCatalog', 'PZMagErrPDFsCatalog']
 
-FILE_PATTERN = r'z_(\d)\S+healpix_(\d+)_magwerr\.h5$'
+FILE_PATTERN = r'z_(\d)\S+withmask.healpix_(\d+)_magwerr\.h5$'
 FILE_PATTERN_PDF = r'photoz_pdf_z_(\d)\S+healpix_(\d+).hdf5'
 FILE_GLOB_PATTERN_PDF = 'photoz_pdf_z_*.hdf5'
 
@@ -43,7 +43,8 @@ class PZMagErrCatalog(BaseGenericCatalog):
         self._native_filter_quantities = {'healpix_pixel', 'redshift_block_lower'}
         self._quantity_modifiers = {
             'redshift': 'redshift',
-            'galaxy_id': 'baseDC2/galaxy_id'
+            'galaxy_id': 'baseDC2/galaxy_id',
+            'photoz_mask': 'photoz_mask'
         }
         for band in ['u','g','r','i','z','y']:
             self._quantity_modifiers['mag_%s_photoz'%band] = 'scatmag_%s'%band
@@ -88,6 +89,11 @@ class PZMagErrCatalog(BaseGenericCatalog):
                                         'compact, single peaked posterior, while'
                                         ' low ODDS values could indicate multiple'
                                         ' peaks or a broad posterior'}
+        self._info_dict['photoz_mask']={'units':'unitless',
+                                        'description':'photoz_mask is a boolean'
+                                        ' mask to match the arrays of the set of'
+                                        ' magnitudes and errors to the subset '
+                                        'with i<26.5 that have photozs computed'}
 
     def _get_quantity_info_dict(self, quantity, default=None):
         return self._info_dict.get(quantity,default)


### PR DESCRIPTION
This PR addresses issue #465 where the match by galaxy_id meant that the large photo-z composite catalogs for the extragalactic catalog failed to load if photoz_pdf was selected, even if return_iterator or native_filter were used.  This update switches the matching to MATCHING_FORMAT, even though the photoz catalog has a different number of rows.  To get the correct masked arrays I've computed a `photoz_mask` column which is added to the `photoz_mock_magnitudes_with_errors_for_cosmoDC2_v1.1.4_image` catalog (also loaded in the `cosmoDC2_v1.1.4_image_with_photozs_v1` composite) which will properly mask the arrays.  This fix also fixes the same issue for the FlexZBoost extragalactic photo-z catalog that will be added in the very near future.

In parallel, I am creating an extragalactic photoz tutorial notebook that will show how to use these catalogs and this new mask.