### PR TITLE
Refactor dc2_photoz_parquet.py

### DIFF
--- a/GCRCatalogs/catalog_configs/photoz_fzboost_for_cosmoDC2_v1.1.4_image.yaml
+++ b/GCRCatalogs/catalog_configs/photoz_fzboost_for_cosmoDC2_v1.1.4_image.yaml
@@ -2,9 +2,7 @@
 
 subclass_name: dc2_photoz_parquet.DC2PhotozGalaxyCatalog
 base_dir: ^/xgal/cosmoDC2/addons/photoz_v1.1.4/FlexZBoost
-catalog_root_dir: /global/cscratch1/sd/schmidt9/CosmoDC2v114_image/FlexZPipe/outputs
-healpix_pattern: fzboost_photoz_pdf_z_{}_{}.step_all.healpix_{}.parquet
-catalog_filename_template: r'fzboost_photoz_pdf_z_(\d)_(\d).step_all.healpix_(\d+).parquet'
+
 healpix_pixels: [8786, 8787, 8788, 8789, 8790, 8791, 8792, 8793, 8794, 8913, 8914, 8915, 8916, 8917, 8918, 8919, 8920, 8921, 9042, 9043, 9044, 9045, 9046, 9047, 9048, 9049,
                  9050, 9169, 9170, 9171, 9172, 9173, 9174, 9175, 9176, 9177, 9178, 9298, 9299, 9300, 9301, 9302, 9303, 9304, 9305, 9306, 9425, 9426, 9427, 9428, 9429, 9430,
                  9431, 9432, 9433, 9434, 9554, 9555, 9556, 9557, 9558, 9559, 9560, 9561, 9562, 9681, 9682, 9683, 9684, 9685, 9686, 9687, 9688, 9689, 9690, 9810, 9811, 9812,
@@ -13,3 +11,4 @@ healpix_pixels: [8786, 8787, 8788, 8789, 8790, 8791, 8792, 8793, 8794, 8913, 891
                  10451, 10452]
 creators: ['Sam Schmidt']
 description: This is a catalog of ML-based photo-z's (using FlexZBoost) for galaxies with i<26.5 in cosmoDC2v1.1.4_image. Note that because only a subset of galaxies have photo-z's, you will need to mask the arrays in composite catalogs in order to return the correct subset containing the objects with photo-z's.
+addon_for: cosmoDC2_v1.1.4_image

--- a/GCRCatalogs/catalog_configs/photoz_fzboost_for_cosmoDC2_v1.1.4_small.yaml
+++ b/GCRCatalogs/catalog_configs/photoz_fzboost_for_cosmoDC2_v1.1.4_small.yaml
@@ -1,2 +1,3 @@
 based_on: photoz_fzboost_for_cosmoDC2_v1.1.4_image
 healpix_pixels: [9559, 9686, 9687, 9814, 9815, 9816, 9942, 9943, 10070, 10071, 10072, 10198, 10199, 10200, 10326, 10327, 10450]
+addon_for: cosmoDC2_v1.1.4_small

--- a/GCRCatalogs/dc2_photoz_parquet.py
+++ b/GCRCatalogs/dc2_photoz_parquet.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 from .dc2_dm_catalog import DC2DMCatalog, DC2DMTractCatalog
 
-__all__ = ['DC2PhotozMixin', 'DC2PhotozGalaxyCatalog', 'DC2PhotozCatalog']
+__all__ = ['DC2PhotozMixin', 'CosmoDC2Parquet', 'DC2PhotozGalaxyCatalog', 'DC2PhotozCatalog']
 
 
 class DC2PhotozMixin:
@@ -56,31 +56,6 @@ class DC2PhotozMixin:
         return self._n_pdf_bins
 
 
-class DC2PhotozCatalog(DC2PhotozMixin, DC2DMTractCatalog):
-    r"""DC2 Parquet Photoz Catalog reader
-
-    Parameters
-    ----------
-    file_dir          (str): Directory of data files being served, required
-    file_pattern      (str): The optional regex pattern of served data files
-    meta_path         (str): path to yaml entries for quantities
-
-    Attributes
-    ----------
-    base_dir          (str): The directory of data files being served
-
-    Notes
-    -----
-    """
-    FILE_DIR = os.path.dirname(os.path.abspath(__file__))
-    FILE_PATTERN = r'photoz_pdf_Run\d\.[0-9a-z]+_tract_\d+\.parquet$'
-    META_PATH = os.path.join(FILE_DIR, 'catalog_configs', '_dc2_photoz_parquet.yaml')
-
-    def _subclass_init(self, **kwargs):
-        super(DC2PhotozCatalog, self)._subclass_init(**kwargs)
-        self._process_pdf_bins(kwargs.get("pdf_bin_info"))
-
-
 class CosmoDC2Parquet(DC2DMCatalog):
 
     _native_filter_quantities = {'healpix_pixel', 'redshift_block_lower'}
@@ -116,21 +91,15 @@ class CosmoDC2Parquet(DC2DMCatalog):
 
 
 class DC2PhotozGalaxyCatalog(DC2PhotozMixin, CosmoDC2Parquet):
-    r"""
-    catalog reader class for cosmoDC2 galaxy catalogs
+    """Parquet Photoz Catalog reader (for cosmoDC2 galaxy catalog)
 
     Parameters
     ----------
-    catalog_root_dir           (str): Directory of data files being served
-                                      required
-    catalog_filename_template  (str): regex pattern of served data files,
-                                      should match pattern used in main
-                                      galaxy catalog
-    healpix_pattern            (str): should match regex pattern, but with {}
-                                      because this pattern is used in
-                                      CosmoDC2ParentClass
+    base_dir          (str): The directory of data files being served
+    file_pattern      (str): The optional regex pattern of served data files
+    meta_path         (str): path to yaml entries for quantities
+    healpix_pixels   (list): List of tracts (integer)
     """
-
     FILE_DIR = os.path.dirname(os.path.abspath(__file__))
     FILE_PATTERN = r'fzboost_photoz_pdf_z_(\d)_(\d).step_all.healpix_(\d+).parquet'
     META_PATH = os.path.join(FILE_DIR, 'catalog_configs', '_dc2_photoz_parquet.yaml')
@@ -145,4 +114,23 @@ class DC2PhotozGalaxyCatalog(DC2PhotozMixin, CosmoDC2Parquet):
 
     def _subclass_init(self, **kwargs):
         super(DC2PhotozGalaxyCatalog, self)._subclass_init(**kwargs)
+        self._process_pdf_bins(kwargs.get("pdf_bin_info"))
+
+
+class DC2PhotozCatalog(DC2PhotozMixin, DC2DMTractCatalog):
+    """DC2 Parquet Photoz Catalog reader
+
+    Parameters
+    ----------
+    base_dir          (str): The directory of data files being served
+    file_pattern      (str): The optional regex pattern of served data files
+    meta_path         (str): path to yaml entries for quantities
+    tracts           (list): List of tracts (integer)
+    """
+    FILE_DIR = os.path.dirname(os.path.abspath(__file__))
+    FILE_PATTERN = r'photoz_pdf_Run\d\.[0-9a-z]+_tract_\d+\.parquet$'
+    META_PATH = os.path.join(FILE_DIR, 'catalog_configs', '_dc2_photoz_parquet.yaml')
+
+    def _subclass_init(self, **kwargs):
+        super(DC2PhotozCatalog, self)._subclass_init(**kwargs)
         self._process_pdf_bins(kwargs.get("pdf_bin_info"))

--- a/GCRCatalogs/dc2_photoz_parquet.py
+++ b/GCRCatalogs/dc2_photoz_parquet.py
@@ -15,13 +15,13 @@ class DC2PhotozMixin:
 
     _PDF_BIN_INFO = {
         'start': 0.005,
-        'stop': 3.0055,
-        'step': 0.01,
+        'stop': 3.005,
+        'nbins': 301,
         'decimals_to_round': 3,
     }
 
     @staticmethod
-    def _generate_modifiers():
+    def _generate_modifiers(**kwargs):
         """Creates a dictionary relating native and homogenized column names
         Returns:
           A dictionary of the form {<homogenized name>: <native name>, ...}
@@ -40,10 +40,10 @@ class DC2PhotozMixin:
 
     def _process_pdf_bins(self, pdf_bin_info=None):
         self._pdf_bin_info = pdf_bin_info or self._PDF_BIN_INFO
-        self._pdf_bin_centers = np.round(np.arange(
+        self._pdf_bin_centers = np.round(np.linspace(
             self._pdf_bin_info['start'],
             self._pdf_bin_info['stop'],
-            self._pdf_bin_info['step'],
+            self._pdf_bin_info['nbins'],
         ), self._pdf_bin_info['decimals_to_round'])
         self._n_pdf_bins = len(self._pdf_bin_centers)
 

--- a/GCRCatalogs/dc2_photoz_parquet.py
+++ b/GCRCatalogs/dc2_photoz_parquet.py
@@ -73,13 +73,13 @@ class CosmoDC2Parquet(DC2DMCatalog):
         except (ValueError, TypeError, AttributeError):
             warnings.warn('Filename {} does not contain correct z/healpix info or not in correct format. Skipped')
             return False
-        return {'zlo': zlo, 'healpix_pixel': hpx}
+        return {'redshift_block_lower': zlo, 'healpix_pixel': hpx}
 
     def _sort_datasets(self, datasets):
         current_healpix_pixels = set(dataset.info['healpix_pixel'] for dataset in datasets)
         if self._healpix_pixels and not all(t in current_healpix_pixels for t in self._healpix_pixels):
             warnings.warn('Not all healpix pixels that were requested are loaded. Use `available_healpix_pixels` to see what pixels have been loaded.')
-        return sorted(datasets, key=lambda d: (d.info['zlo'], d.info['healpix_pixel']))
+        return sorted(datasets, key=lambda d: (d.info['redshift_block_lower'], d.info['healpix_pixel']))
 
     @property
     def available_healpix_pixels(self):

--- a/GCRCatalogs/dc2_photoz_parquet.py
+++ b/GCRCatalogs/dc2_photoz_parquet.py
@@ -4,24 +4,27 @@ DC2 Parquet Photo-z Catalog Reader
 
 import os
 import re
-import pandas as pd
+import warnings
 import numpy as np
-import yaml
-import pyarrow.parquet as pq
-from .dc2_dm_catalog import DC2DMTractCatalog, ParquetFileWrapper
-from .cosmodc2 import CosmoDC2ParentClass
-from .utils import first
-from GCR import BaseGenericCatalog
+from .dc2_dm_catalog import DC2DMCatalog, DC2DMTractCatalog
 
-__all__ = ['DC2PhotozMixin','DC2PhotozGalaxyCatalog','DC2PhotozCatalog']
+__all__ = ['DC2PhotozMixin', 'DC2PhotozGalaxyCatalog', 'DC2PhotozCatalog']
 
-class DC2PhotozMixin(object):
+
+class DC2PhotozMixin:
+
+    _PDF_BIN_INFO = {
+        'start': 0.005,
+        'stop': 3.0055,
+        'step': 0.01,
+        'decimals_to_round': 3,
+    }
 
     @staticmethod
     def _generate_modifiers():
         """Creates a dictionary relating native and homogenized column names
         Returns:
-          A dictionary of the form {<homogenized name>: <native name>, ...}     
+          A dictionary of the form {<homogenized name>: <native name>, ...}
         """
         modifiers = {
             'photoz_odds': 'ODDS',
@@ -35,6 +38,15 @@ class DC2PhotozMixin(object):
         }
         return modifiers
 
+    def _process_pdf_bins(self, pdf_bin_info=None):
+        self._pdf_bin_info = pdf_bin_info or self._PDF_BIN_INFO
+        self._pdf_bin_centers = np.round(np.arange(
+            self._pdf_bin_info['start'],
+            self._pdf_bin_info['stop'],
+            self._pdf_bin_info['step'],
+        ), self._pdf_bin_info['decimals_to_round'])
+        self._n_pdf_bins = len(self._pdf_bin_centers)
+
     @property
     def photoz_pdf_bin_centers(self):
         return self._pdf_bin_centers
@@ -44,121 +56,7 @@ class DC2PhotozMixin(object):
         return self._n_pdf_bins
 
 
-class DC2PhotozGalaxyCatalog(CosmoDC2ParentClass,DC2PhotozMixin):
-    r"""
-    catalog reader class for cosmoDC2 galaxy catalogs
-
-    Parameters
-    ----------
-    catalog_root_dir           (str): Directory of data files being served 
-                                      required
-    catalog_filename_template  (str): regex pattern of served data files, 
-                                      should match pattern used in main
-                                      galaxy catalog
-    healpix_pattern            (str): should match regex pattern, but with {}
-                                      because this pattern is used in 
-                                      CosmoDC2ParentClass
-    """
-
-    _FILE_PATTERN = r'fzboost_photoz_pdf_z_(\d)_(\d).step_all.healpix_(\d+).parquet'
-    FILE_DIR = os.path.dirname(os.path.abspath(__file__))
-    META_PATH = os.path.join(FILE_DIR,
-                             'catalog_configs/_dc2_photoz_parquet.yaml')
-    
-    # FlexZBoost has slightly different binning than BPZ
-    _PDF_BIN_INFO = {
-        'start': 0.0,
-        'stop': 3.0,
-        'nbins': 301,
-        'decimals_to_round': 3,
-    }
-
-
-    def _subclass_init(self, catalog_root_dir, catalog_filename_template, healpix_pattern, **kwargs):
-        # pylint: disable=W0221
-        self._pdf_bin_info = kwargs.get('pdf_bin_info', self._PDF_BIN_INFO)
-        self._pdf_bin_centers = np.round(np.linspace(self._pdf_bin_info['start'],
-                                                   self._pdf_bin_info['stop'],
-                                                   self._pdf_bin_info['nbins'],
-        ), self._pdf_bin_info['decimals_to_round'])
-        self._n_pdf_bins = len(self._pdf_bin_centers)
-        
-        if not os.path.isdir(catalog_root_dir):
-            raise ValueError('Catalog directory {} does not exist'.format(catalog_root_dir))
-        self._native_filter_quantities = {'healpix_pixel', 'redshift_block_lower'}
-        self._quantity_modifiers = self._generate_modifiers()
-        self.base_dir = catalog_root_dir
-        self.healpix_pattern = healpix_pattern
-        self._filename_pattern = kwargs.get('catalog_filename_template', self._FILE_PATTERN)
-        self._filename_re = re.compile(self._filename_pattern)
-
-        self._file_list = self._get_healpix_file_list(catalog_root_dir,
-                                        healpix_pattern,
-                                        **kwargs)
-
-        self._healpix_files = self._file_list # needed in CosmoDC2ParentClass
-        self._datasets = self._generate_datasets()
-        self._columns = first(self._datasets).columns
-
-
-    @staticmethod
-    def _obtain_native_data_dict(native_quantities_needed, native_quantity_getter):
-        """                                                               
-        Overloading this so that we can query the database backend
-        for multiple columns at once
-        """
-        return native_quantity_getter.read_columns(list(native_quantities_needed), as_dict=True)
-
-    def _extract_dataset_info(self, filename):
-        """
-        Should return a dict that contains infomation of each dataset
-        that is parsed from the filename
-        Should return None if no infomation need to be stored
-        Should return False if this dataset needs to be skipped
-        Parameters:
-        ----------
-        filename (str)
-          the filename of the chunk of data
-        Returns:
-        -------
-        data_info: (dict)
-          a dictionary of file attributes, in this case zlo, zhi, and
-          healpix_pixel
-        """
-        fname_pattern = self.healpix_pattern.format(r'(\d)', r'(\d)', r'(\d+)')
-        mat = re.match(fname_pattern, filename)
-        zlo_x, _, hpx_x = tuple(map(int, mat.groups()))
-        data_info = {'zlo':zlo_x, 'healpix_pixel':hpx_x}
-        return data_info
-
-    def _generate_native_quantity_list(self):
-        return pd.read_parquet(first(self._healpix_files.values()),engine='pyarrow').columns.tolist()
-
-    def _generate_datasets(self):
-        """Return viable data sets from all files in self.base_dir
-        Returns:
-            A list of ObjectTableWrapper(<file path>, <key>) objects 
-            for all files and keys
-        """
-        datasets = list()
-        for xfname in self._file_list.values():
-            fname = xfname.split(self.base_dir+"/")[-1]
-            if not self._filename_re.match(fname):
-                continue
-            info = self._extract_dataset_info(fname)
-            if info is False:
-                continue
-            datasets.append(ParquetFileWrapper(xfname, info))
-        return datasets
-
-    def _iter_native_dataset(self, native_filters=None):
-        for dataset in self._datasets:
-            if native_filters is not None and not native_filters.check_scalar(dataset.info):
-                continue
-            yield dataset
-
-
-class DC2PhotozCatalog(DC2DMTractCatalog,DC2PhotozMixin):
+class DC2PhotozCatalog(DC2PhotozMixin, DC2DMTractCatalog):
     r"""DC2 Parquet Photoz Catalog reader
 
     Parameters
@@ -174,32 +72,77 @@ class DC2PhotozCatalog(DC2DMTractCatalog,DC2PhotozMixin):
     Notes
     -----
     """
-
     FILE_DIR = os.path.dirname(os.path.abspath(__file__))
     FILE_PATTERN = r'photoz_pdf_Run\d\.[0-9a-z]+_tract_\d+\.parquet$'
-    META_PATH = os.path.join(FILE_DIR,
-                             'catalog_configs/_dc2_photoz_parquet.yaml')
+    META_PATH = os.path.join(FILE_DIR, 'catalog_configs', '_dc2_photoz_parquet.yaml')
 
+    def _subclass_init(self, **kwargs):
+        super(DC2PhotozCatalog, self)._subclass_init(**kwargs)
+        self._process_pdf_bins(kwargs.get("pdf_bin_info"))
+
+
+class CosmoDC2Parquet(DC2DMCatalog):
+
+    _native_filter_quantities = {'healpix_pixel', 'redshift_block_lower'}
+
+    def _subclass_init(self, **kwargs):
+        self._healpix_pixels = None
+        if kwargs.get('healpix_pixels') is not None:
+            self._healpix_pixels = [int(t) for t in kwargs['healpix_pixels']]
+        super()._subclass_init(**kwargs)
+
+    def _extract_dataset_info(self, filename):
+        match = re.match(self.FILE_PATTERN, filename)
+        try:
+            zlo, _, hpx = tuple(map(int, match.groups()))
+        except (ValueError, TypeError, AttributeError):
+            warnings.warn('Filename {} does not contain correct z/healpix info or not in correct format. Skipped')
+            return False
+        return {'zlo': zlo, 'healpix_pixel': hpx}
+
+    def _sort_datasets(self, datasets):
+        current_healpix_pixels = set(dataset.info['healpix_pixel'] for dataset in datasets)
+        if self._healpix_pixels and not all(t in current_healpix_pixels for t in self._healpix_pixels):
+            warnings.warn('Not all healpix pixels that were requested are loaded. Use `available_healpix_pixels` to see what pixels have been loaded.')
+        return sorted(datasets, key=lambda d: (d.info['zlo'], d.info['healpix_pixel']))
+
+    @property
+    def available_healpix_pixels(self):
+        """Returns a sorted list of available tracts
+        Returns:
+            A sorted list of available tracts as integers
+        """
+        return [dataset.info['healpix_pixel'] for dataset in self._datasets]
+
+
+class DC2PhotozGalaxyCatalog(DC2PhotozMixin, CosmoDC2Parquet):
+    r"""
+    catalog reader class for cosmoDC2 galaxy catalogs
+
+    Parameters
+    ----------
+    catalog_root_dir           (str): Directory of data files being served
+                                      required
+    catalog_filename_template  (str): regex pattern of served data files,
+                                      should match pattern used in main
+                                      galaxy catalog
+    healpix_pattern            (str): should match regex pattern, but with {}
+                                      because this pattern is used in
+                                      CosmoDC2ParentClass
+    """
+
+    FILE_DIR = os.path.dirname(os.path.abspath(__file__))
+    FILE_PATTERN = r'fzboost_photoz_pdf_z_(\d)_(\d).step_all.healpix_(\d+).parquet'
+    META_PATH = os.path.join(FILE_DIR, 'catalog_configs', '_dc2_photoz_parquet.yaml')
+
+    # FlexZBoost has slightly different binning than BPZ
     _PDF_BIN_INFO = {
-        'start': 0.005,
-        'stop': 3.0055,
-        'step': 0.01,
+        'start': 0.0,
+        'stop': 3.0,
+        'nbins': 301,
         'decimals_to_round': 3,
     }
 
     def _subclass_init(self, **kwargs):
-        """
-        Wraps default init method to apply various corrections to the catalog.
-        """
-
-        # grab bin info as kwarg, or default to run2.2i values.
-        self._pdf_bin_info = kwargs.get('pdf_bin_info', self._PDF_BIN_INFO)
-        self._pdf_bin_centers = np.round(np.arange(self._pdf_bin_info['start'],
-                                                   self._pdf_bin_info['stop'],
-                                                   self._pdf_bin_info['step'],
-        ), self._pdf_bin_info['decimals_to_round'])
-        self._n_pdf_bins = len(self._pdf_bin_centers)
-
-        super(DC2PhotozCatalog, self)._subclass_init(**kwargs)
-
-
+        super(DC2PhotozGalaxyCatalog, self)._subclass_init(**kwargs)
+        self._process_pdf_bins(kwargs.get("pdf_bin_info"))


### PR DESCRIPTION
@sschmidt23 I've attempted to refactor `dc2_photoz_parquet.py` (as part of the review for #457). 

It turns out my suggestion of subclassing `CosmoDC2ParentClass` was not great; as it has too much custom methods specific for cosmoDC2. Since you are using parquet files, I found that simply subclassing `DC2DMCatalog` and implementing the healpix/zlo native filters work well. 

Hence I created a new `CosmoDC2Parquet` that is a subclass of `DC2DMCatalog`. `CosmoDC2Parquet` is similar to `DC2DMTractCatalog` but use healpix/zlo instead of tract. With this new class, `DC2PhotozGalaxyCatalog` is then just a very simple mixin of `DC2PhotozMixin` and `CosmoDC2Parquet`. 

I have not tested my implementation since NERSC is down.



A side note for @JoanneBogart --- When implementing `CosmoDC2Parquet` I was hoping to use the new `PathInfoParser` but not sure if it works for this case. In particular, the filename pattern is `some_prefix_z_(\d)_(\d).step_all.healpix_(\d+).parquet`, but I want to call the first integer `redshift_block_lower`, ignore the second integer, and call the third integer `healpix_pixel`. I'm not sure if I can customize `PathInfoParser` to this extend? 