### PR TITLE
Add DR6c matched catalogs

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6c_matched.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6c_matched.yaml
@@ -1,7 +1,7 @@
 #  Use ^/ to indicate file path relative to GCR root dir
 
 subclass_name: dc2_matched_table.DC2MatchedTable
-table_dir: /global/cscratch1/sd/jsanch87/DC2_Run2.2i
+table_dir: ^/DC2-prod/Run2.2i/addons/matched/dr6c
 table_filename_template: matched_ids_dc2_object_run{}_{}_{{}}.fits.gz
 data_release: dr6c
 version: '2.2i'

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6c_matched.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6c_matched.yaml
@@ -1,0 +1,15 @@
+#  Use ^/ to indicate file path relative to GCR root dir
+
+subclass_name: dc2_matched_table.DC2MatchedTable
+table_dir: /global/cscratch1/sd/jsanch87/DC2_Run2.2i
+table_filename_template: matched_ids_dc2_object_run{}_{}_{{}}.fits.gz
+data_release: dr6c
+version: '2.2i'
+truth_version: 'dc2_truth_run2.2i_galaxy_truth_summary'
+object_id: 'objectId'
+truth_id: 'truthId'
+match_flag: 'is_matched'
+is_star: 'is_star'
+creator: 'Javier Sanchez'
+description: 'This is the table of matches between the object catalog and the extragalactic catalog'
+addon_for: dc2_object_run2.2i_dr6c

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6c_matched_addon.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6c_matched_addon.yaml
@@ -1,0 +1,11 @@
+#  Use ^/ to indicate file path relative to GCR root dir
+
+subclass_name: composite.CompositeReader
+description: DC2 Run 2.2i Object Catalog with Matched Table addon
+creators: ['Javi Sanchez', 'Eve Kovacs']
+catalogs:
+  - catalog_name: dc2_object_run2.2i_dr6c
+    matching_method: MATCHING_ORDER
+  - catalog_name: dc2_object_run2.2i_dr6c_matched
+    matching_method: MATCHING_ORDER
+include_in_default_catalog_list: true


### PR DESCRIPTION
This PR is similar to #472 but adding matched catalogs to DR6c rather than DR6a. Files are still in my scratch space (with read permissions for the `lsst` group). 
