### PR TITLE
faster access to number of rows for parquet files

### DIFF
--- a/GCRCatalogs/parquet.py
+++ b/GCRCatalogs/parquet.py
@@ -54,7 +54,7 @@ class ParquetFileWrapper():
         self._handle = None
 
     def __len__(self):
-        return int(self.handle.scan_contents)
+        return self.handle.metadata.num_rows
 
     def __contains__(self, item):
         return item in self.columns


### PR DESCRIPTION
This PR adapts the method suggested by @joezuntz in #477. Fix #477. 

@JoanneBogart can you check if it works as expected for catalogs that contain row groups?
