### PR TITLE
add reader for rand forest PZ for CSDC2_114_small

### DIFF
--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_with_photoz_SKRF_v1.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_with_photoz_SKRF_v1.yaml
@@ -1,0 +1,9 @@
+#  Use ^/ to indicate file path relative to GCR root dir
+
+subclass_name: composite.CompositeReader
+only_use_master_attr: false
+catalogs:
+ - catalog_name: cosmoDC2_v1.1.4_small
+   matching_method: galaxy_id
+ - catalog_name: photoz_SKRF_v1_for_cosmoDC2_v1.1.4_small
+   matching_method: galaxy_id

--- a/GCRCatalogs/catalog_configs/photoz_SKRF_v1_for_cosmoDC2_v1.1.4_small.yaml
+++ b/GCRCatalogs/catalog_configs/photoz_SKRF_v1_for_cosmoDC2_v1.1.4_small.yaml
@@ -1,6 +1,6 @@
 # test for olivia photo-z's
 
 subclass_name: dc2_photoz_parquet.PZSKRFCatalog
-base_dir: /global/cfs/cdirs/lsst/shared/xgal/cosmoDC2/addons/photoz_v1.1.4/10_year_error_estimates/OLIVIA_WORK
+base_dir: ^/xgal/cosmoDC2/addons/photoz_v1.1.4/10_year_error_estimates/OLIVIA_WORK
 filename: final-result.parquet
 addon_for: cosmoDC2_v1.1.4_small

--- a/GCRCatalogs/catalog_configs/photoz_SKRF_v1_for_cosmoDC2_v1.1.4_small.yaml
+++ b/GCRCatalogs/catalog_configs/photoz_SKRF_v1_for_cosmoDC2_v1.1.4_small.yaml
@@ -1,0 +1,6 @@
+# test for olivia photo-z's
+
+subclass_name: dc2_photoz_parquet.PZSKRFCatalog
+base_dir: /global/cfs/cdirs/lsst/groups/PZ/PhotoZDC2/COSMODC2v1.1.4/10_year_error_estimates/OLIVIA_WORK
+filename: final-result.parquet
+addon_for: cosmoDC2_v1.1.4_small

--- a/GCRCatalogs/catalog_configs/photoz_SKRF_v1_for_cosmoDC2_v1.1.4_small.yaml
+++ b/GCRCatalogs/catalog_configs/photoz_SKRF_v1_for_cosmoDC2_v1.1.4_small.yaml
@@ -1,6 +1,6 @@
 # test for olivia photo-z's
 
 subclass_name: dc2_photoz_parquet.PZSKRFCatalog
-base_dir: /global/cfs/cdirs/lsst/groups/PZ/PhotoZDC2/COSMODC2v1.1.4/10_year_error_estimates/OLIVIA_WORK
+base_dir: /global/cfs/cdirs/lsst/shared/xgal/cosmoDC2/addons/photoz_v1.1.4/10_year_error_estimates/OLIVIA_WORK
 filename: final-result.parquet
 addon_for: cosmoDC2_v1.1.4_small

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -639,7 +639,6 @@ class DC2ObjectCatalog(BaseGenericCatalog):
         return set(self._schema).union(self._native_filter_quantities)
 
     def _iter_native_dataset(self, native_filters=None):
-        # pylint: disable=C0330
         for dataset in self._datasets:
             if (native_filters is None or
                 native_filters.check_scalar(dataset.tract_and_patch)):


### PR DESCRIPTION
> If this pull request is to address specific issues, please add "fix #ISSUE_NUMBER" below so that when this PR is merged, the associated issues will be automatically closed. Always use a short but descriptive title; avoid using "issues/xxx" as title.

This PR addresses issue #479 to make a reader for the subset of cosmoDC2_v1.1.4_small galaxies with photo-z's generated by Olivia/Markus.  Added a new subclass to deal with the unique quantity modifiers and single file storage.  Things seem to work properly, and were tested by Olivia for functionality.  

Right now the data file is specified with a hard link in the config yaml and resides in the PZ directories at NERSC.  We can either keep this, or copy the file to the shared directory and update to a relative path, not sure which is better.