### PR TITLE
remove only_use_master_attr from 3 pz files

### DIFF
--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image_with_photozs_flexzboost_v1.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image_with_photozs_flexzboost_v1.yaml
@@ -1,5 +1,4 @@
 subclass_name: composite.CompositeReader
-only_use_master_attr: true
 description: |
      Composite catalog that matches the "observed" photometry catalog for
      cosmoDC2_v1.1.4_image (with names "scatmag_[band]" and "scaterr_[band]")

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image_with_photozs_v1.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_image_with_photozs_v1.yaml
@@ -1,7 +1,6 @@
 #  Use ^/ to indicate file path relative to GCR root dir
 
 subclass_name: composite.CompositeReader
-only_use_master_attr: true
 description: |
      Composite catalog that matches the "observed" photometry catalog for
      cosmoDC2_v1.1.4_image (with names "scatmag_[band]" and "scaterr_[band]")

--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_with_photoz_SKRF_v1.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_small_with_photoz_SKRF_v1.yaml
@@ -1,7 +1,6 @@
 #  Use ^/ to indicate file path relative to GCR root dir
 
 subclass_name: composite.CompositeReader
-only_use_master_attr: false
 catalogs:
  - catalog_name: cosmoDC2_v1.1.4_small
    matching_method: galaxy_id


### PR DESCRIPTION
This PR addresses issue #475 and is a simple deletion of the "only_use_master_attr" parameter from three photo-z files.  Setting this prevented the @property photoz_pdf_bin_centers from being accessible in two of the catalogs (third one set it to false, which is the default, so the line is unnecessary).

Tested functionality in the branch, everything works as expected.