### PR TITLE
Set base_dir to Run2.2i-dr6-wfd-v1 instead of dr6d

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_v1_with_metacal.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_v1_with_metacal.yaml
@@ -17,7 +17,7 @@ catalogs:
              5065, 5066, 5067, 5068, 5069, 5070, 5071, 5072, 5073, 5074]
     matching_method: MATCHING_FORMAT
   - subclass_name: dc2_metacal.DC2MetacalCatalog
-    base_dir: ^/DC2-prod/Run2.2i/dpdd/Run2.2i-dr6d/metacal_table_summary
+    base_dir: ^/DC2-prod/Run2.2i/dpdd/Run2.2i-dr6-wfd-v1/metacal_table_summary
     tracts: [2723, 2724, 2725, 2726, 2727, 2728, 2729, 2730, 2731, 2732, 2733, 2734, 2735,
              2896, 2897, 2898, 2899, 2900, 2901, 2902, 2903, 2904, 2905, 2906, 2907, 2908,
              3074, 3075, 3076, 3077, 3078, 3079, 3080, 3081, 3082, 3083, 3084, 3085, 3086,


### PR DESCRIPTION
fix #487 
The metacal base directory was pointing to dr6d, which was never released - we instead moved to dr6-wfd-v1.  The `shared` area at NERSC already reflects this directory structure and to avoid errors when using GCRCatalogs, we need to keep the directories referenced consistent.