### PR TITLE
Added new config files for WFD matched catalogs

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_matched.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_matched.yaml
@@ -1,0 +1,15 @@
+#  Use ^/ to indicate file path relative to GCR root dir
+
+subclass_name: dc2_matched_table.DC2MatchedTable
+table_dir: ^/DC2-prod/Run2.2i/addons/matched/dr6
+table_filename_template: matched_ids_dc2_object_run{}_{}_{{}}.fits.gz
+data_release: dr6_wfd_with_metacal
+version: '2.2i'
+truth_version: 'dc2_truth_run2.2i_galaxy_truth_summary'
+object_id: 'objectId'
+truth_id: 'truthId'
+match_flag: 'is_matched'
+is_star: 'is_star'
+creator: 'Javier Sanchez'
+description: 'This is the table of matches between the object catalog and the extragalactic catalog'
+addon_for: dc2_object_run2.2i_dr6_wfd_with_metacal

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_matched_addon.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_matched_addon.yaml
@@ -1,0 +1,11 @@
+#  Use ^/ to indicate file path relative to GCR root dir
+
+subclass_name: composite.CompositeReader
+description: DC2 Run 2.2i Object Catalog with Matched Table addon
+creators: ['Javi Sanchez', 'Eve Kovacs']
+catalogs:
+  - catalog_name: dc2_object_run2.2i_dr6_wfd_with_metacal
+    matching_method: MATCHING_ORDER
+  - catalog_name: dc2_object_run2.2i_dr6_wfd_matched
+    matching_method: MATCHING_ORDER
+include_in_default_catalog_list: true


### PR DESCRIPTION
This PR addresses #492. I tested this at jupyter and it seems to work. I associated the files to `dr6_wfd_with_metacal` but I'm happy to just associate it to `dr6_wfd`.