### PR TITLE
Add dc2 Run2.2i truth catalogs to default list

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_galaxy_truth_summary.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_galaxy_truth_summary.yaml
@@ -5,3 +5,4 @@ base_dir: ^/DC2-prod/Run2.2i/truth/galtruth
 filename_pattern: 'truth_summary_hp{healpix}.parquet$'
 description: DC2 Run 2.2i  Summary truth table for galaxies
 creators: ['Joanne Bogart']
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_sn_truth_summary.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_sn_truth_summary.yaml
@@ -5,3 +5,4 @@ base_dir: ^/DC2-prod/Run2.2i/truth/sntruth
 filename_pattern: 'sn_truth_summary.parquet$'
 description: DC2 Run 2.2i  Summary truth table for SNe
 creators: ['Joanne Bogart']
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_sn_variability_truth.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_sn_variability_truth.yaml
@@ -5,3 +5,4 @@ base_dir: ^/DC2-prod/Run2.2i/truth/sntruth
 filename_pattern: 'sn_variability_truth.parquet$'
 description: DC2 Run 2.2i  variability truth table for SNe
 creators: ['Joanne Bogart']
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_star_lc_stats.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_star_lc_stats.yaml
@@ -5,3 +5,4 @@ base_dir: ^/DC2-prod/Run2.2i/truth/startruth
 filename_pattern: 'star_lc_stats_trimmed.parquet$'
 description: DC2 Run 2.2i  Summary truth table for stars
 creators: ['Joanne Bogart']
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_star_truth_summary.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_star_truth_summary.yaml
@@ -5,3 +5,4 @@ base_dir: ^/DC2-prod/Run2.2i/truth/startruth
 filename_pattern: 'star_truth_summary.parquet$'
 description: DC2 Run 2.2i  Summary truth table for stars
 creators: ['Joanne Bogart']
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_star_variability_truth.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_run2.2i_star_variability_truth.yaml
@@ -5,3 +5,4 @@ base_dir: ^/DC2-prod/Run2.2i/truth/startruth
 filename_pattern: 'star_variability_truth.parquet$'
 description: DC2 Run 2.2i  variability truth table for SNe
 creators: ['Joanne Bogart']
+include_in_default_catalog_list: true


### PR DESCRIPTION
Run 2.2i truth catalogs belong in the default list.  Up till now only truth from Run 1.2 was showing up there.