### PR TITLE
Truth-match catalog reader

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_with_truth_match.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_with_truth_match.yaml
@@ -5,6 +5,8 @@ catalogs:
   - catalog_name: dc2_object_run2.2i_dr6_wfd_v1
     tracts: [3259]  # TODO: to be removed
   - catalog_name: dc2_truth_match_run2.2i_dr6_wfd
+    as_object_addon: true
+    as_truth_table: false
     matching_method: MATCHING_FORMAT   # For GCR 0.8.x. TODO: to be removed
     # Below are for GCR v0.9.0 new composite features
     matching_partition: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_with_truth_match.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_with_truth_match.yaml
@@ -1,13 +1,11 @@
 subclass_name: composite.CompositeReader
-description: DC2 Run 2.2i Object Catalog with Truth Match Table
+description: DC2 Run 2.2i Object Catalog with Truth Match Information
 creators: ['DESC DC2 Team']
 catalogs:
   - catalog_name: dc2_object_run2.2i_dr6_wfd_v1
-    tracts: [3259]  # TODO: to be removed
   - catalog_name: dc2_truth_match_run2.2i_dr6_wfd
     as_object_addon: true
     as_truth_table: false
-    matching_method: MATCHING_FORMAT   # For GCR 0.8.x. TODO: to be removed
     # Below are for GCR v0.9.0 new composite features
     matching_partition: true
     matching_row_order: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_with_truth_match.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_with_truth_match.yaml
@@ -1,0 +1,15 @@
+subclass_name: composite.CompositeReader
+description: DC2 Run 2.2i Object Catalog with Truth Match Table
+creators: ['DESC DC2 Team']
+catalogs:
+  - catalog_name: dc2_object_run2.2i_dr6_wfd_v1
+    tracts: [3259]  # TODO: to be removed
+  - catalog_name: dc2_truth_match_run2.2i_dr6_wfd
+    matching_method: MATCHING_FORMAT   # For GCR 0.8.x. TODO: to be removed
+    # Below are for GCR v0.9.0 new composite features
+    matching_partition: true
+    matching_row_order: true
+    overwrite_quantities: false
+    overwrite_attributes: false
+    include_native_quantities: false
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_match_run2.2i_dr6_wfd.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_match_run2.2i_dr6_wfd.yaml
@@ -1,6 +1,6 @@
 subclass_name: dc2_truth_match.DC2TruthMatchCatalog
-base_dir: /global/cscratch1/sd/yymao/desc/truth_run2.2_merged  # TODO: update to final path when ready
+base_dir: ^/DC2-prod/Run2.2i/truth/matching_dr6_wfd
 as_truth_table: true
-description: DC2 Run 2.2i DR6 WFD v1 Truth-Match Table
+description: DC2 Run 2.2i Truth Catalog in tracts
 creators: ['DESC DC2 Team']
 include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_truth_match_run2.2i_dr6_wfd.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_match_run2.2i_dr6_wfd.yaml
@@ -1,5 +1,5 @@
 subclass_name: dc2_truth_match.DC2TruthMatchCatalog
-base_dir: ^/DC2-prod/Run2.2i/truth/matching_dr6_wfd
+base_dir: ^/DC2-prod/Run2.2i/truth/tract_partition/match_dr6_wfd
 as_truth_table: true
 description: DC2 Run 2.2i Truth Catalog in tracts
 creators: ['DESC DC2 Team']

--- a/GCRCatalogs/catalog_configs/dc2_truth_match_run2.2i_dr6_wfd.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_truth_match_run2.2i_dr6_wfd.yaml
@@ -1,0 +1,6 @@
+subclass_name: dc2_truth_match.DC2TruthMatchCatalog
+base_dir: /global/cscratch1/sd/yymao/desc/truth_run2.2_merged  # TODO: update to final path when ready
+as_truth_table: true
+description: DC2 Run 2.2i DR6 WFD v1 Truth-Match Table
+creators: ['DESC DC2 Team']
+include_in_default_catalog_list: true

--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -12,7 +12,6 @@ import re
 import warnings
 
 import numpy as np
-import pyarrow.parquet as pq
 import yaml
 from GCR import BaseGenericCatalog
 from .parquet import ParquetFileWrapper

--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -278,7 +278,7 @@ class DC2DMCatalog(BaseGenericCatalog):
 
 class DC2DMTractCatalog(DC2DMCatalog):
     _native_filter_quantities = {'tract'}
-    FILE_PATTERN = r'.+_tract_\d+\.parquet$'
+    FILE_PATTERN = r'.+_tract_?\d+\.parquet$'
 
     def _subclass_init(self, **kwargs):
         self._tracts = None
@@ -317,7 +317,7 @@ class DC2DMTractCatalog(DC2DMCatalog):
 
 class DC2DMVisitCatalog(DC2DMCatalog):
     _native_filter_quantities = {'visit'}
-    FILE_PATTERN = r'.+_visit_\d+\.parquet$'
+    FILE_PATTERN = r'.+_visit_?\d+\.parquet$'
 
     def _subclass_init(self, **kwargs):
         self._visits = None

--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -291,7 +291,7 @@ class DC2DMTractCatalog(DC2DMCatalog):
         super()._subclass_init(**kwargs)
 
     def _extract_dataset_info(self, filename):
-        match = re.search(r'tract_(\d+)', filename)
+        match = re.search(r'tract_?(\d+)', filename)
         if match is None:
             warnings.warn('Filename {} does not contain tract info or not in correct format. Skipped')
             return False
@@ -330,7 +330,7 @@ class DC2DMVisitCatalog(DC2DMCatalog):
         super()._subclass_init(**kwargs)
 
     def _extract_dataset_info(self, filename):
-        match = re.search(r'visit_(\d+)', filename)
+        match = re.search(r'visit_?(\d+)', filename)
         if match is None:
             warnings.warn('Filename {} does not contain visit info or not in correct format. Skipped')
             return False

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -44,7 +44,7 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
         if self._as_object_addon:
             no_postfix = ("is_unique_truth_entry", "match_sep", "match_objectId")
             self._quantity_modifiers = {
-                (k + ("" if k in no_postfix else "_truth"): v for k, v in self._quantity_modifiers.items()
+                (k + ("" if k in no_postfix else "_truth")): v for k, v in self._quantity_modifiers.items()
             }
 
     def _obtain_native_data_dict(self, native_quantities_needed, native_quantity_getter):

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -1,0 +1,83 @@
+"""
+Reader for truth-match catalogs persisted as parquet files and partitioned in tracts.
+"""
+import numpy as np
+import astropy.units as u
+
+from .dc2_dm_catalog import DC2DMTractCatalog
+
+__all__ = ["DC2TruthMatchCatalog"]
+
+
+def _flux_to_mag(flux):
+    return (flux * u.nJy).to_value(u.ABmag)  # pylint: disable=no-member
+
+
+class DC2TruthMatchCatalog(DC2DMTractCatalog):
+    r"""
+    DC2 Truth-Match (parquet) Catalog reader
+
+    Presents tables exactly as they are defined in the files (no aliases,
+    no derived quantities)
+
+    Parameters
+    ----------
+    base_dir          (str): Directory of data files being served, required
+    filename_pattern  (str): The optional regex pattern of served data files
+    as_object_addon  (bool): If set, return rows in the the same row order as object catalog
+    as_truth_table   (bool): If set, remove duplicated truth rows
+    """
+
+    def _subclass_init(self, **kwargs):
+
+        super()._subclass_init(**dict(kwargs, is_dpdd=True))  # set is_dpdd=True to obtain bare modifiers
+
+        self._as_object_addon = bool(kwargs.get("as_object_addon"))
+        self._as_truth_table = bool(kwargs.get("as_truth_table"))
+        if self._as_object_addon and self._as_truth_table:
+            raise ValueError("Reader options `as_object_addon` and `as_truth_table` cannot both be set to True.")
+
+        flux_cols = [k for k in self._quantity_modifiers if k.startswith("flux_")]
+        for col in flux_cols:
+            self._quantity_modifiers["mag_" + col.partition("_")[2]] = (_flux_to_mag, col)
+
+        if self._as_object_addon:
+            self._quantity_modifiers = {(k + "_truth"): v for k, v in self._quantity_modifiers.items()}
+
+    def _obtain_native_data_dict(self, native_quantities_needed, native_quantity_getter):
+        """
+        Overloading this so that we can query the database backend
+        for multiple columns at once
+        """
+        native_quantities_needed = set(native_quantities_needed)
+        if self._as_object_addon:
+            native_quantities_needed.add("match_objectId")
+        elif self._as_truth_table:
+            native_quantities_needed.add("is_unique_truth_entry")
+
+        columns = list(native_quantities_needed)
+        d = native_quantity_getter.read_columns(columns, as_dict=False)
+        if self._as_object_addon:
+            mask = d["match_objectId"].values > -1
+            return {c: d[c].values[mask] for c in columns}
+        elif self._as_truth_table:
+            mask = d["is_unique_truth_entry"].values
+            return {c: d[c].values[mask] for c in columns}
+        return {c: d[c].values for c in columns}
+
+    def __len__(self):
+        if self._len is None:
+            # pylint: disable=attribute-defined-outside-init
+            if self._as_object_addon:
+                self._len = sum(
+                    np.count_nonzero(d["match_objectId"] > -1)
+                    for d in self.get_quantities(["match_objectId"], return_iterator=True)
+                )
+            elif self._as_truth_table:
+                self._len = sum(
+                    np.count_nonzero(d["is_unique_truth_entry"])
+                    for d in self.get_quantities(["is_unique_truth_entry"], return_iterator=True)
+                )
+            else:
+                self._len = sum(len(dataset) for dataset in self._datasets)
+        return self._len

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -42,7 +42,10 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
             self._quantity_modifiers["mag_" + col.partition("_")[2]] = (_flux_to_mag, col)
 
         if self._as_object_addon:
-            self._quantity_modifiers = {(k + "_truth"): v for k, v in self._quantity_modifiers.items()}
+            no_postfix = ("is_unique_truth_entry", "match_sep", "match_objectId")
+            self._quantity_modifiers = {
+                (k + ("" if k in no_postfix else "_truth"): v for k, v in self._quantity_modifiers.items()
+            }
 
     def _obtain_native_data_dict(self, native_quantities_needed, native_quantity_getter):
         """

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -43,7 +43,7 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
             self._quantity_modifiers["mag_" + col.partition("_")[2]] = (_flux_to_mag, col)
 
         if self._as_object_addon:
-            no_postfix = ("is_unique_truth_entry", "match_sep", "match_objectId")
+            no_postfix = ("truth_type", "is_unique_truth_entry", "match_sep", "match_objectId")
             self._quantity_modifiers = {
                 (k + ("" if k in no_postfix else "_truth")): (v or k) for k, v in self._quantity_modifiers.items()
             }

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -44,7 +44,7 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
         if self._as_object_addon:
             no_postfix = ("is_unique_truth_entry", "match_sep", "match_objectId")
             self._quantity_modifiers = {
-                (k + ("" if k in no_postfix else "_truth")): v for k, v in self._quantity_modifiers.items()
+                (k + ("" if k in no_postfix else "_truth")): (v or k) for k, v in self._quantity_modifiers.items()
             }
 
     def _obtain_native_data_dict(self, native_quantities_needed, native_quantity_getter):

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -18,8 +18,20 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
     r"""
     DC2 Truth-Match (parquet) Catalog reader
 
-    Presents tables exactly as they are defined in the files (no aliases,
-    no derived quantities)
+    This reader is intended for reading the truth-match catalog that is in
+    parquet format and partitioned by tracts.
+
+    Two options, `as_object_addon` and `as_truth_table` further control,
+    respectively, whether the returned table contains only rows that match
+    to the object catalog (`as_object_addon=True`), or only unique truth
+    entries (`as_truth_table=True`).
+
+    When `as_object_addon` is set, most column names will also be decorated
+    with a `_truth` postfix.
+
+    The underlying truth-match catalog files contain fluxes but not magnitudes.
+    The reader provides translation to magnitude (using `_flux_to_mag`) for
+    convenience. No other translation is applied.
 
     Parameters
     ----------
@@ -50,8 +62,10 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
 
     def _obtain_native_data_dict(self, native_quantities_needed, native_quantity_getter):
         """
-        Overloading this so that we can query the database backend
-        for multiple columns at once
+        When `as_object_addon` or `as_truth_table` is set, we need to filter the table
+        based on `match_objectId` or `is_unique_truth_entry` before the data is returned .
+        To achieve such, we have to overwrite this method to inject the additional columns
+        and to apply the masks.
         """
         native_quantities_needed = set(native_quantities_needed)
         if self._as_object_addon:

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -10,7 +10,8 @@ __all__ = ["DC2TruthMatchCatalog"]
 
 
 def _flux_to_mag(flux):
-    return (flux * u.nJy).to_value(u.ABmag)  # pylint: disable=no-member
+    with np.errstate(divide="ignore"):
+        return (flux * u.nJy).to_value(u.ABmag)  # pylint: disable=no-member
 
 
 class DC2TruthMatchCatalog(DC2DMTractCatalog):


### PR DESCRIPTION
This PR add a truth-match catalog reader and relevant catalog configs. It fixes #500. 

PR is ready for review, but the path in catalog configs will need to be updated once we generate all the truth-match files and move then to the share space. #509 is opened to keep track of this.

In the composite config, I have added several options that will be available once we upgrade to GCR v0.9.0. Right now those options are ignored by GCR v0.8.x.

The quantity modifiers in the truth-match reader are a bit hack-y. They work fine, but I welcome better ideas. 