### PR TITLE
Use the improved composite in GCR v0.9.0

### DIFF
--- a/GCRCatalogs/composite.py
+++ b/GCRCatalogs/composite.py
@@ -3,13 +3,7 @@ composite reader
 """
 import warnings
 
-from GCR import CompositeCatalog
-_HAS_NEW_COMPOSITE = True
-try:
-    from GCR import CompositeSpecs
-except ImportError:
-    from GCR.composite import MATCHING_FORMAT, MATCHING_ORDER
-    _HAS_NEW_COMPOSITE = False
+from GCR import CompositeSpecs, CompositeCatalog
 
 from .register import load_catalog, load_catalog_from_config_dict, has_catalog
 
@@ -17,8 +11,6 @@ from .register import load_catalog, load_catalog_from_config_dict, has_catalog
 class CompositeReader(CompositeCatalog):
     def __init__(self, **kwargs):
         instances = []
-        identifiers = []
-        methods = []
         for catalog_dict in kwargs['catalogs']:
             catalog_name = catalog_dict.get('catalog_name') or catalog_dict.get('based_on')
             if has_catalog(catalog_name):
@@ -29,21 +21,8 @@ class CompositeReader(CompositeCatalog):
                 catalog = load_catalog_from_config_dict(catalog_dict)
             else:
                 raise ValueError('catalog config must specify `catalog_name`, `based_on`, or `subclass_name`')
+            instances.append(CompositeSpecs(catalog, catalog_name, **catalog_dict))
 
-            if _HAS_NEW_COMPOSITE:
-                instances.append(CompositeSpecs(catalog, catalog_name, **catalog_dict))
-            else:
-                instances.append(catalog)
-                identifiers.append(catalog_name)
-                method = catalog_dict.get('matching_method', 'MATCHING_FORMAT')
-                if method == 'MATCHING_FORMAT':
-                    method = MATCHING_FORMAT
-                elif method == 'MATCHING_ORDER':
-                    method = MATCHING_ORDER
-                methods.append(method)
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', 'CompositeCatalog is still an experimental feature')
-            super(CompositeReader, self).__init__(instances, identifiers, methods, **kwargs)
-
-        if not _HAS_NEW_COMPOSITE:
-            self.__len__ = instances[0].__len__
+            super(CompositeReader, self).__init__(instances, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     keywords='GCR',
     packages=['GCRCatalogs'],
-    install_requires=['requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.8.8'],
+    install_requires=['requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.9.0'],
     extras_require={
         'full': ['h5py', 'healpy', 'pandas', 'pyarrow', 'tables'],
     },


### PR DESCRIPTION
I am improving the composite catalog class in https://github.com/yymao/generic-catalog-reader/pull/32. Once GCR is updated to 0.9.0, we should merge this PR to make use the new composite class. 

This PR will fix #398 and fix #410.