### PR TITLE
Change decode to be compatible with v2 and v3 of h5py

### DIFF
--- a/GCRCatalogs/agn.py
+++ b/GCRCatalogs/agn.py
@@ -28,11 +28,11 @@ class AGNCatalog(BaseGenericCatalog):
             raise RuntimeError("Catalog directory %s does not exist." % (base_dir))
 
         self._path = os.path.join(base_dir, filename)
-        self._handle = h5py.File(self._path)
+        self._handle = h5py.File(self._path, 'r')
         self._quantity_modifiers = self._generate_quantity_modifiers()
         self.lightcone = kwargs.get('lightcone', True)
         self.sky_area = kwargs.get('sky_area', None)
-        
+
     def __del__(self):
         self._handle.close()
 
@@ -47,7 +47,7 @@ class AGNCatalog(BaseGenericCatalog):
             'halo_mass':                                    'halo_mass',
             'is_central':                                   'is_central',
             'Mag_true_i_agnonly_lsst_z0':                   'M_i(extincted)',
-            'Mag_true_i_agnonly_no_agn_extinction_lsst_z0': 'M_i', 
+            'Mag_true_i_agnonly_no_agn_extinction_lsst_z0': 'M_i',
             'ra':                                           'ra',
             'redshift':                                     'redshift',
             'stellar_mass':                                 'stellar_mass',
@@ -80,10 +80,10 @@ class AGNCatalog(BaseGenericCatalog):
                                                                                     'Mag_true_{}_lsst_z0'.format(band),
                                                                                     'M_{}(extincted)'.format(band),
                                                                                    )
-            
+
         return quantity_modifiers
 
-    
+
     def _iter_native_dataset(self, native_filters=None):
         if native_filters is not None:
             raise RuntimeError("*native_filters* not supported")

--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -10,7 +10,7 @@ import numpy as np
 import h5py
 from astropy.cosmology import FlatLambdaCDM
 from GCR import BaseGenericCatalog
-from .utils import md5
+from .utils import md5, decode
 
 __all__ = ['AlphaQGalaxyCatalog']
 __version__ = '5.0.0'
@@ -361,7 +361,7 @@ class AlphaQGalaxyCatalog(BaseGenericCatalog):
             quantity_key = 'galaxyProperties/' + quantity
             if quantity_key not in fh:
                 return default
-            modifier = lambda k, v: None if k == 'description' and v == b'None given' else v.decode()
+            modifier = lambda k, v: None if k == 'description' and decode(v) == 'None given' else decode(v)
             return_qty = {k: modifier(k, v) for k, v in fh[quantity_key].attrs.items()}
             # a hot fix of the units of native halo mass (hostHaloMass) and x for v3+
             if self.catalog_version >= StrictVersion('3.0') and quantity == 'hostHaloMass':

--- a/GCRCatalogs/cosmodc2.py
+++ b/GCRCatalogs/cosmodc2.py
@@ -14,7 +14,7 @@ import h5py
 import healpy as hp
 from astropy.cosmology import FlatLambdaCDM
 from GCR import BaseGenericCatalog
-from .utils import md5, first
+from .utils import md5, first, decode
 
 __all__ = ['CosmoDC2GalaxyCatalog', 'BaseDC2GalaxyCatalog', 'BaseDC2SnapshotGalaxyCatalog',
            'BaseDC2ShearCatalog', 'CosmoDC2AddonCatalog']
@@ -232,7 +232,7 @@ class CosmoDC2ParentClass(BaseGenericCatalog):
 
         if collect_info_dict:
             quantity_info_dict = dict()
-            modifier = lambda k, v: None if k == 'description' and v == b'None given' else v.decode()
+            modifier = lambda k, v: None if k == 'description' and decode(v) == 'None given' else decode(v)
             for quantity in native_quantities:
                 quantity_info_dict[quantity] = {k: modifier(k, v) for k, v in fh[group_name][quantity].attrs.items()}
             return native_quantities, quantity_info_dict

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -15,6 +15,7 @@ from GCR import BaseGenericCatalog
 
 from .dc2_dm_catalog import DC2DMTractCatalog
 from .dc2_dm_catalog import convert_flux_to_mag, convert_flux_to_nanoJansky, convert_nanoJansky_to_mag, convert_flux_err_to_mag_err
+from .utils import decode
 
 __all__ = ['DC2ObjectCatalog', 'DC2ObjectParquetCatalog']
 
@@ -121,7 +122,7 @@ class TableWrapper():
                 for i in range(self.storer.nblocks):
                     dtype = getattr(self.storer.group, 'block{}_values'.format(i)).dtype.name
                     for col in getattr(self.storer.group, 'block{}_items'.format(i)):
-                        self._native_schema[col.decode()] = {'dtype': dtype}
+                        self._native_schema[decode(col)] = {'dtype': dtype}
         return self._native_schema
 
     @property

--- a/GCRCatalogs/utils.py
+++ b/GCRCatalogs/utils.py
@@ -37,7 +37,10 @@ def first(iterable, default=None):
 
 def decode(bytestring):
     """
-    decode a bytestring is possible
+    Decode a bytestring is possible, return str if not.
+
+    Only bytestring has .decode() method. This utility provides a way to homogenize values
+    that may be bytestring or unicode string  (such as the attributes in h5py v2.x and v3.x).
     """
     try:
         return bytestring.decode()

--- a/GCRCatalogs/utils.py
+++ b/GCRCatalogs/utils.py
@@ -37,7 +37,7 @@ def first(iterable, default=None):
 
 def decode(bytestring):
     """
-    Decode a bytestring is possible, return str if not.
+    Decode a bytestring if possible, return str if not.
 
     Only bytestring has .decode() method. This utility provides a way to homogenize values
     that may be bytestring or unicode string  (such as the attributes in h5py v2.x and v3.x).

--- a/GCRCatalogs/utils.py
+++ b/GCRCatalogs/utils.py
@@ -3,7 +3,8 @@ utility module
 """
 import hashlib
 
-__all__ = ['md5', 'is_string_like']
+__all__ = ['md5', 'is_string_like', 'first', 'decode']
+
 
 def md5(fname, chunk_size=65536):
     """
@@ -32,3 +33,13 @@ def first(iterable, default=None):
     returns the first element of `iterable`
     """
     return next(iter(iterable), default)
+
+
+def decode(bytestring):
+    """
+    decode a bytestring is possible
+    """
+    try:
+        return bytestring.decode()
+    except AttributeError:
+        return str(bytestring)


### PR DESCRIPTION
This PR fixes #497. 

In `desc-python` the `h5py` package is in v2.10.0, while in `desc-python-bleed` it is in v3.1.0. They process bytestring differently. In v2, bytestring remains bytestring while in v3, it is converted to unicode string. 

In our reader we have assumed v2 behavior, and hence call `.decode()` to convert to unicode string. This  action will fail with h5py v3. Hence, a new utility function `decode` is added to decode if input is bytestring, otherwise just return. By using this utility function we can be compatible with both v2 and v3 of `h5py`. 

I have tested this implementation on cosmoDC2 with both ``desc-python` and `desc-python-bleed`. Both cases work. 