### PR TITLE
Use MATCHING_FORMAT for Javi's matched add-ons

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1.1i_matched_addon.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1.1i_matched_addon.yaml
@@ -5,7 +5,7 @@ description: DC2 Run 2.1.1i Object Catalog with Matched Table addon
 creators: ['Javi Sanchez', 'Eve Kovacs']
 catalogs:
   - catalog_name: dc2_object_run2.1.1i
-    matching_method: MATCHING_ORDER
+    matching_method: MATCHING_FORMAT
   - catalog_name: dc2_object_run2.1.1i_matched
-    matching_method: MATCHING_ORDER
+    matching_method: MATCHING_FORMAT
 deprecated: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_matched_addon.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_matched_addon.yaml
@@ -5,7 +5,7 @@ description: DC2 Run 2.1 Object Catalog with Matched Table addon
 creators: ['Javi Sanchez', 'Eve Kovacs']
 catalogs:
   - catalog_name: dc2_object_run2.1i_dr1
-    matching_method: MATCHING_ORDER
+    matching_method: MATCHING_FORMAT
   - catalog_name: dc2_object_run2.1i_dr1b_matched
-    matching_method: MATCHING_ORDER
+    matching_method: MATCHING_FORMAT
 deprecated: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_matched_addon_tract3830.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.1i_dr1b_matched_addon_tract3830.yaml
@@ -5,7 +5,7 @@ description: DC2 Run 2.1 Object Catalog with Matched Table addon
 creators: ['Javi Sanchez', 'Eve Kovacs']
 catalogs:
   - catalog_name: dc2_object_run2.1i_dr1_tract3830
-    matching_method: MATCHING_ORDER
+    matching_method: MATCHING_FORMAT
   - catalog_name: dc2_object_run2.1i_dr1b_matched_tract3830
-    matching_method: MATCHING_ORDER
+    matching_method: MATCHING_FORMAT
 deprecated: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_matched_addon.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_wfd_matched_addon.yaml
@@ -4,8 +4,10 @@ subclass_name: composite.CompositeReader
 description: DC2 Run 2.2i Object Catalog with Matched Table addon
 creators: ['Javi Sanchez', 'Eve Kovacs']
 catalogs:
-  - catalog_name: dc2_object_run2.2i_dr6_wfd_with_metacal
-    matching_method: MATCHING_ORDER
+  - catalog_name: dc2_object_run2.2i_dr6_wfd_v1
+    matching_method: MATCHING_FORMAT
+  - subclass_name: dc2_metacal.DC2MetacalCatalog
+    base_dir: ^/DC2-prod/Run2.2i/dpdd/Run2.2i-dr6-wfd-v1/metacal_table_summary
   - catalog_name: dc2_object_run2.2i_dr6_wfd_matched
-    matching_method: MATCHING_ORDER
+    matching_method: MATCHING_FORMAT
 include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6a_matched_addon.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6a_matched_addon.yaml
@@ -5,7 +5,7 @@ description: DC2 Run 2.2i Object Catalog with Matched Table addon
 creators: ['Javi Sanchez', 'Eve Kovacs']
 catalogs:
   - catalog_name: dc2_object_run2.2i_dr6a
-    matching_method: MATCHING_ORDER
+    matching_method: MATCHING_FORMAT
   - catalog_name: dc2_object_run2.2i_dr6a_matched
-    matching_method: MATCHING_ORDER
+    matching_method: MATCHING_FORMAT
 include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6c_matched_addon.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6c_matched_addon.yaml
@@ -5,7 +5,7 @@ description: DC2 Run 2.2i Object Catalog with Matched Table addon
 creators: ['Javi Sanchez', 'Eve Kovacs']
 catalogs:
   - catalog_name: dc2_object_run2.2i_dr6c
-    matching_method: MATCHING_ORDER
+    matching_method: MATCHING_FORMAT
   - catalog_name: dc2_object_run2.2i_dr6c_matched
-    matching_method: MATCHING_ORDER
+    matching_method: MATCHING_FORMAT
 include_in_default_catalog_list: true


### PR DESCRIPTION
@fjaviersanchez I just noticed that you have been using the `MATCHING_ORDER` option for your matched add-ons. While `MATCHING_ORDER` would work, the performance is not as good as `MATCHING_FORMAT`. The former requires the row ordering to be the same, while the latter requires both row ordering *and* partition methods to be the same across catalogs. 

I believe in your mached catalog, the partition method is indeed by tract, and hence these add-ons should qualify using `MATCHING_FORMAT`. Looking at your reader, I noticed that you have not implemented native_filters for tracts, which is also required for `MATCHING_FORMAT` to work. So I implemented the native filter and change the `matching_method` to `MATCHING_FORMAT` in several configs. 

I have also further edited `dc2_object_run2.2i_dr6_wfd_matched_addon` --- composite of composite will slow down the performance. But it's totally fine to have more than 2 catalogs in one composite. So I changed your composite of composite into 3 catalogs in one composite. 

Side note: I have to admit that name `MATCHING_FORMAT` is not precise. It seems to suggest the underlying format needs to match, but that's not what it means. In GCR v0.9.0 (https://github.com/yymao/generic-catalog-reader/pull/32), I introduced `matching_partition` and `matching_row_order` to be more precise.