### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -3,8 +3,6 @@ name: DESC Env Docker Build Test
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   docker-build:

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -1,35 +1,32 @@
-name: desc-env-test
+name: DESC Env Docker Build Test
 
 on:
-  # Trigger the workflow on push, but only for the master branch
   push:
-    branches:
-      - master
+    branches: [ master ]
 
 jobs:
-  build:
-    name: Build on Ubuntu
+  docker-build:
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+       include:
+         - docker_name: updateGCRpy
+           docker_image: lsstdesc/desc-python:latest
+           docker_image_updated: lsstdesc/desc-python:test
+           conda_activate: "conda activate desc;"
+           setup_script: /usr/local/py3.7/etc/profile.d/conda.sh
+         - docker_name: updateGCRstack
+           docker_image: lsstdesc/stack-jupyter:prod
+           docker_image_updated: lsstdesc/stack-jupyter:test
+           conda_activate: ""
+           setup_script: /opt/lsst/software/stack/loadLSST.bash
+
     steps:
-      - name: Docker login
-        run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username heather999 --password-stdin
-      - name: checkout gcr-catalogs
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-  #    - name: pull desc-stack
-  #      run: docker pull lsstdesc/stack-jupyter:prod 
-      - name: pull desc-python - using latest for now
-        run: docker pull lsstdesc/desc-python:latest
-      - name: Install gcr master in desc-python
-        run: docker run --name="updateGCRpy" lsstdesc/desc-python:latest /bin/bash -c "source /usr/local/py3.7/etc/profile.d/conda.sh; conda activate desc; pip install https://github.com/LSSTDESC/gcr-catalogs/archive/master.zip"
-   #   - name: Install gcr master in desc-stack:test
-   #     run: docker run --name="updateGCRstack" lsstdesc/stack-jupyter:prod /bin/bash -c "source /opt/lsst/software/stack/loadLSST.bash; pip install https://github.com/LSSTDESC/gcr-catalogs/archive/master.zip"
-      - name: docker commit desc-python:test
-        run: docker commit -m="Installed latest GCR master" updateGCRpy lsstdesc/desc-python:test
-    #  - name: docker commit desc-stack:test
-    #    run: docker commit -m="Installed latest GCR master" updateGCRstack lsstdesc/stack-jupyter:test
-      - name: push desc-python
-        run: docker push lsstdesc/desc-python:test
-    #  - name: push desc-stack
-    #   run: docker push lsstdesc/stack-jupyter:test
+      - name: docker login
+        run: docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_ACCESSTOK }}
+      - run: docker pull ${{ matrix.docker_image }}
+      - name: Install master branch of ${{ github.repository }}
+        run: docker run --name=${{ matrix.docker_name }} ${{ matrix.docker_image }} /bin/bash \
+          -c "source ${{ matrix.setup_script }}; ${{ matrix.conda_activate }} pip install https://github.com/${{ github.repository }}/archive/master.zip"
+      - run: docker commit -m="Installed ${{ github.repository }} master" ${{ matrix.docker_name }} ${{ matrix.docker_image_updated }}
+      - run: docker push ${{ matrix.docker_image_updated }}

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -17,18 +17,18 @@ jobs:
            docker_image_updated: lsstdesc/desc-python:test
            conda_activate: "conda activate desc;"
            setup_script: /usr/local/py3.7/etc/profile.d/conda.sh
-         - docker_name: updateGCRstack
-           docker_image: lsstdesc/stack-jupyter:prod
-           docker_image_updated: lsstdesc/stack-jupyter:test
-           conda_activate: ""
-           setup_script: /opt/lsst/software/stack/loadLSST.bash
+         ## Disable stack build for now
+         #- docker_name: updateGCRstack
+         #  docker_image: lsstdesc/stack-jupyter:prod
+         #  docker_image_updated: lsstdesc/stack-jupyter:test
+         #  conda_activate: ""
+         #  setup_script: /opt/lsst/software/stack/loadLSST.bash
 
     steps:
       - name: docker login
-        run: docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_ACCESSTOK }}
+        run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
       - run: docker pull ${{ matrix.docker_image }}
       - name: Install master branch of ${{ github.repository }}
-        run: docker run --name=${{ matrix.docker_name }} ${{ matrix.docker_image }} /bin/bash \
-          -c "source ${{ matrix.setup_script }}; ${{ matrix.conda_activate }} pip install https://github.com/${{ github.repository }}/archive/master.zip"
+        run: docker run --name=${{ matrix.docker_name }} ${{ matrix.docker_image }} /bin/bash -c "source ${{ matrix.setup_script }}; ${{ matrix.conda_activate }} pip install https://github.com/${{ github.repository }}/archive/master.zip"
       - run: docker commit -m="Installed ${{ github.repository }} master" ${{ matrix.docker_name }} ${{ matrix.docker_image_updated }}
       - run: docker push ${{ matrix.docker_image_updated }}

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -3,6 +3,8 @@ name: DESC Env Docker Build Test
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   docker-build:

--- a/.github/workflows/python-ci-test.yml
+++ b/.github/workflows/python-ci-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.9]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-ci-test.yml
+++ b/.github/workflows/python-ci-test.yml
@@ -1,15 +1,17 @@
-name: Python package
+name: Python CI Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
-  build:
-
+  ci-test:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: [3.7, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -21,7 +23,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-py${{ matrix.python-version }}-pip-
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-ci-test.yml
+++ b/.github/workflows/python-ci-test.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install wheel
         pip install .[full]
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-ci-test.yml
+++ b/.github/workflows/python-ci-test.yml
@@ -7,11 +7,11 @@ on:
     branches: [ master ]
 
 jobs:
-  ci-test:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR updates the github actions workflows. 

In `desc-env-test.yml`, while the stack build has been commented out, the workflow can use the `matrix` strategy to be more concise. There is also no need to check out the repo for this workflow to run. 

Using this opportunity I also updated the python ci test to give it a better name and add python 3.9 to the test. 