### PR TITLE
add dr2 truth-match catalog config

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr2_matched_addon.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr2_matched_addon.yaml
@@ -1,0 +1,16 @@
+subclass_name: composite.CompositeReader
+description: DC2 Run 2.2i DR2 Object Catalog with Truth Match Information
+creators: ['DESC DC2 Team']
+catalogs:
+  - catalog_name: dc2_object_run2.2i_dr2_v1
+  - subclass_name: dc2_truth_match.DC2TruthMatchCatalog
+    base_dir: ^/DC2-prod/Run2.2i/truth/tract_partition/match_dr2
+    as_object_addon: true
+    as_matchdc2_schema: true
+    # Below are for GCR v0.9.0 new composite features
+    matching_partition: true
+    matching_row_order: true
+    overwrite_quantities: false
+    overwrite_attributes: false
+    include_native_quantities: false
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr2_with_truth_match.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr2_with_truth_match.yaml
@@ -1,0 +1,16 @@
+subclass_name: composite.CompositeReader
+description: DC2 Run 2.2i DR2 Object Catalog with Truth Match Information
+creators: ['DESC DC2 Team']
+catalogs:
+  - catalog_name: dc2_object_run2.2i_dr2_v1
+  - subclass_name: dc2_truth_match.DC2TruthMatchCatalog
+    base_dir: ^/DC2-prod/Run2.2i/truth/tract_partition/match_dr2
+    as_object_addon: true
+    as_truth_table: false
+    # Below are for GCR v0.9.0 new composite features
+    matching_partition: true
+    matching_row_order: true
+    overwrite_quantities: false
+    overwrite_attributes: false
+    include_native_quantities: false
+include_in_default_catalog_list: true

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -11,7 +11,9 @@ __all__ = ["DC2TruthMatchCatalog"]
 
 def _flux_to_mag(flux):
     with np.errstate(divide="ignore"):
-        return (flux * u.nJy).to_value(u.ABmag)  # pylint: disable=no-member
+        mag = (flux * u.nJy).to_value(u.ABmag)  # pylint: disable=no-member
+    mag[~np.isfinite(mag)] = np.nan  # homogenize inf and nan
+    return mag
 
 
 class DC2TruthMatchCatalog(DC2DMTractCatalog):

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -115,8 +115,6 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
         cf. https://github.com/fjaviersanchez/MatchDC2/blob/master/python/matchDC2.py
         """
 
-        native_columns = list(self._quantity_modifiers)
-
         quantity_modifiers = {
             "truthId": (lambda i, t: np.where(t < 3, i, "-1").astype(np.int64), "id", "truth_type"),
             "objectId": "match_objectId",
@@ -128,15 +126,16 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
             "dist": "match_sep",
         }
 
-        for col in native_columns:
+        for col in self._columns:
             if col.startswith("flux_") and col.endswith("_noMW"):
                 quantity_modifiers["mag_" + col.split("_")[1] + "_lsst"] = (_flux_to_mag, col)
 
         quantity_modifiers['galaxy_match_mask'] = (lambda t, m: (t == 1) & m, "truth_type", "is_good_match")
         quantity_modifiers['star_match_mask'] = (lambda t, m: (t == 2) & m, "truth_type", "is_good_match")
 
-        # put into self for `self.add_derived_quantity` to work
+        # put these into self for `self.add_derived_quantity` to work
         self._quantity_modifiers = quantity_modifiers
+        self._native_quantities = set(self._columns)
 
         for col in list(quantity_modifiers):
             if col in ("is_matched", "is_star", "galaxy_match_mask", "star_match_mask"):

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -57,7 +57,7 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
             self._quantity_modifiers["mag_" + col.partition("_")[2]] = (_flux_to_mag, col)
 
         if self._as_object_addon:
-            no_postfix = ("truth_type", "is_unique_truth_entry", "match_sep", "match_objectId")
+            no_postfix = ("truth_type", "match_objectId", "match_sep", "is_good_match", "is_nearest_neighbor", "is_unique_truth_entry")
             self._quantity_modifiers = {
                 (k + ("" if k in no_postfix else "_truth")): (v or k) for k, v in self._quantity_modifiers.items()
             }

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -78,8 +78,8 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
         columns = list(native_quantities_needed)
         d = native_quantity_getter.read_columns(columns, as_dict=False)
         if self._as_object_addon:
-            mask = d["match_objectId"].values > -1
-            return {c: d[c].values[mask] for c in columns}
+            n = np.count_nonzero(d["match_objectId"].values > -1)
+            return {c: d[c].values[:n] for c in columns}
         elif self._as_truth_table:
             mask = d["is_unique_truth_entry"].values
             return {c: d[c].values[mask] for c in columns}

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -56,7 +56,7 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
             raise ValueError("Reader options `as_object_addon` and `as_truth_table` cannot both be set to True.")
 
         if self._as_matchdc2_schema:
-            self._quantity_modifiers = self._generate_matchdc2_quantity_modifiers(list(self._quantity_modifiers))
+            self._use_matchdc2_quantity_modifiers()
             return
 
         flux_cols = [k for k in self._quantity_modifiers if k.startswith("flux_")]
@@ -109,12 +109,13 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
                 self._len = sum(len(dataset) for dataset in self._datasets)
         return self._len
 
-    @staticmethod
-    def _generate_matchdc2_quantity_modifiers(native_columns):
+    def _use_matchdc2_quantity_modifiers(self):
         """
         To recreate column names in dc2_matched_table.py
         cf. https://github.com/fjaviersanchez/MatchDC2/blob/master/python/matchDC2.py
         """
+
+        native_columns = list(self._quantity_modifiers)
 
         quantity_modifiers = {
             "truthId": (lambda i, t: np.where(t < 3, i, "-1").astype(np.int64), "id", "truth_type"),
@@ -131,12 +132,19 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
             if col.startswith("flux_") and col.endswith("_noMW"):
                 quantity_modifiers["mag_" + col.split("_")[1] + "_lsst"] = (_flux_to_mag, col)
 
-        for col in list(quantity_modifiers):
-            if col in ("is_matched", "is_star"):
-                continue
-            quantity_modifiers[col + "_galaxy"] = (lambda d, t, m: np.ma.array(d, mask=((t == 1) & m)), col, "truth_type", "is_good_match")
-            quantity_modifiers[col + "_star"] = (lambda d, t, m: np.ma.array(d, mask=((t == 2) & m)), col, "truth_type", "is_good_match")
         quantity_modifiers['galaxy_match_mask'] = (lambda t, m: (t == 1) & m, "truth_type", "is_good_match")
         quantity_modifiers['star_match_mask'] = (lambda t, m: (t == 2) & m, "truth_type", "is_good_match")
 
-        return quantity_modifiers
+        # put into self for `self.add_derived_quantity` to work
+        self._quantity_modifiers = quantity_modifiers
+
+        for col in list(quantity_modifiers):
+            if col in ("is_matched", "is_star", "galaxy_match_mask", "star_match_mask"):
+                continue
+            for t in ("galaxy", "star"):
+                self.add_derived_quantity(
+                    "{}_{}".format(col, t),
+                    lambda d, m: np.ma.array(d, mask=m),
+                    col,
+                    "{}_match_mask".format(t),
+                )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     keywords='GCR',
     packages=['GCRCatalogs'],
-    install_requires=['requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.9.0'],
+    install_requires=['requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.9.1'],
     extras_require={
         'full': ['h5py', 'healpy', 'pandas', 'pyarrow', 'tables'],
     },


### PR DESCRIPTION
This PR adds add the truth-match catalog config for Run2.21 DR2 (v1). 

@evevkovacs you may be able to use this catalog for validation. ~but keep in mind that:~
~1. The column names may differ slightly from @fjaviersanchez's version~
~2. This version of truth-match only use nearest neighbor, without magnitude cut. There may be more mismatches especially given that DR2 is shallower.~

Updated Dec 12: The two points I noted above no longer apply with the latest set of commits (which fixed point 1) and with https://github.com/LSSTDESC/DC2-production/pull/409 (which fixed point 2). 