### PR TITLE
Add _pixel postfix to I<xx,yy,xy> and family

### DIFF
--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -122,23 +122,21 @@ which is determined from the reference filter for each source (the filter that b
 Quantity Label | Unit | Definition | GCRbase | DPDD
 --- | --- | --- | --- | ---
 `ra` | degree | Right Ascension | x | xx |
-`ra_err` | degree | Right Ascension | x | xx |
 `dec` | degree | Declination | x | xx |
-`dec_err` | degree | Declination | x | xx |
-`x` | pixels | 2D centroid location (x coordinate). |   | xx |
-`y` | pixels | 2D centroid location (y coordinate). |   | xx |
-`xErr` | pixels | Error value for `centroidX`. |   | xx |
-`yErr` | pixels | Error value for `centroidY`. |   | xx |
+`x` | pixel | 2D centroid location (x coordinate). |   | xx |
+`y` | pixel | 2D centroid location (y coordinate). |   | xx |
+`xErr` | pixel | Error value for `centroidX`. |   | xx |
+`yErr` | pixel | Error value for `centroidY`. |   | xx |
 `xy_flag` | - | Flag for issues with `x` and `y`. |   | xx |
 `psFlux_<band>` | nJy | Point source model flux in `<band>.` |   | x |
 `psFluxErr_<band>` | nJy | Error value for `psFlux_<band>`. |   | x |
 `psFlux_flag_<band>` | - | Flag for issues with `psFlux_<band>`. |   | x |
-`Ixx_<band>` | asec2 | Adaptive second moment of the source intensity in `<band>`. |   | x |
-`Iyy_<band>` | asec2 | Adaptive second moment of the source intensity in `<band>`. |   | x |
-`Ixy_<band>` | asec2 | Adaptive second moment of the source intensity in `<band>`. |   | x |
-`IxxPSF_<band>` | asec2 | Adaptive second moment of the PSF  in `<band>`. |   | x |
-`IyyPSF_<band>` | asec2 | Adaptive second moment of the PSF  in `<band>`. |   | x |
-`IxyPSF_<band>` | asec2 | Adaptive second moment of the PSF  in `<band>`. |   | x |
+`Ixx_pixel_<band>` | pixel | Adaptive second moment of the source intensity in `<band>`. |   | xx |
+`Iyy_pixel_<band>` | pixel | Adaptive second moment of the source intensity in `<band>`. |   | xx |
+`Ixy_pixel_<band>` | pixel | Adaptive second moment of the source intensity in `<band>`. |   | xx |
+`IxxPSF_pixel_<band>` | pixel | Adaptive second moment of the PSF  in `<band>`. |   | xx |
+`IyyPSF_pixel_<band>` | pixel | Adaptive second moment of the PSF  in `<band>`. |   | xx |
+`IxyPSF_pixel_<band>` | pixel | Adaptive second moment of the PSF  in `<band>`. |   | xx |
 `I_flag_<band>` | - | Flag for issues with `Ixx_<band>`, `Ixx_<band>`, and `Ixx_<band>.` |   | x |
 `cModelFlux_<band>` | nJy | composite model (CModel) flux in `<band>` | x |  |
 `cModelFluxErr_<band>` | nJy | Error value for cModel flux in `<band>` | x |  |
@@ -157,7 +155,7 @@ Quantity Label | Unit | Definition | GCRbase | DPDD
 
 Source Catalog contains information about high signal-to-noise detections on single frame images,
 
-Forced Source Catalog contains fixed-position photometry measurements performed on individual 
+Forced Source Catalog contains fixed-position photometry measurements performed on individual
 exposures based on the positions from objects in the Object Catalog.
 
 Quantity Label | Unit | Definition | GCRbase | DPDD

--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -131,12 +131,12 @@ Quantity Label | Unit | Definition | GCRbase | DPDD
 `psFlux_<band>` | nJy | Point source model flux in `<band>.` |   | x |
 `psFluxErr_<band>` | nJy | Error value for `psFlux_<band>`. |   | x |
 `psFlux_flag_<band>` | - | Flag for issues with `psFlux_<band>`. |   | x |
-`Ixx_pixel_<band>` | pixel | Adaptive second moment of the source intensity in `<band>`. |   | xx |
-`Iyy_pixel_<band>` | pixel | Adaptive second moment of the source intensity in `<band>`. |   | xx |
-`Ixy_pixel_<band>` | pixel | Adaptive second moment of the source intensity in `<band>`. |   | xx |
-`IxxPSF_pixel_<band>` | pixel | Adaptive second moment of the PSF  in `<band>`. |   | xx |
-`IyyPSF_pixel_<band>` | pixel | Adaptive second moment of the PSF  in `<band>`. |   | xx |
-`IxyPSF_pixel_<band>` | pixel | Adaptive second moment of the PSF  in `<band>`. |   | xx |
+`Ixx_pixel_<band>` | pixel^2 | Adaptive second moment of the source intensity in `<band>`. |   | xx |
+`Iyy_pixel_<band>` | pixel^2 | Adaptive second moment of the source intensity in `<band>`. |   | xx |
+`Ixy_pixel_<band>` | pixel^2 | Adaptive second moment of the source intensity in `<band>`. |   | xx |
+`IxxPSF_pixel_<band>` | pixel^2 | Adaptive second moment of the PSF  in `<band>`. |   | xx |
+`IyyPSF_pixel_<band>` | pixel^2 | Adaptive second moment of the PSF  in `<band>`. |   | xx |
+`IxyPSF_pixel_<band>` | pixel^2 | Adaptive second moment of the PSF  in `<band>`. |   | xx |
 `I_flag_<band>` | - | Flag for issues with `Ixx_<band>`, `Ixx_<band>`, and `Ixx_<band>.` |   | x |
 `cModelFlux_<band>` | nJy | composite model (CModel) flux in `<band>` | x |  |
 `cModelFluxErr_<band>` | nJy | Error value for cModel flux in `<band>` | x |  |

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -373,8 +373,8 @@ class DC2ObjectCatalog(BaseGenericCatalog):
         # cross-band average, second moment values
         modifiers['I_flag'] = 'ext_shapeHSM_HsmSourceMoments_flag'
         for ax in ['xx', 'yy', 'xy']:
-            modifiers['I{}'.format(ax)] = 'ext_shapeHSM_HsmSourceMoments_{}'.format(ax)
-            modifiers['I{}PSF'.format(ax)] = 'base_SdssShape_psf_{}'.format(ax)
+            modifiers['I{}_pixel'.format(ax)] = 'ext_shapeHSM_HsmSourceMoments_{}'.format(ax)
+            modifiers['I{}PSF_pixel'.format(ax)] = 'base_SdssShape_psf_{}'.format(ax)
 
         for band in bands:
             modifiers['mag_{}'.format(band)] = '{}_mag'.format(band)
@@ -388,8 +388,8 @@ class DC2ObjectCatalog(BaseGenericCatalog):
             modifiers['I_flag_{}'.format(band)] = '{}_base_SdssShape_flag'.format(band)
 
             for ax in ['xx', 'yy', 'xy']:
-                modifiers['I{}_{}'.format(ax, band)] = '{}_base_SdssShape_{}'.format(band, ax)
-                modifiers['I{}PSF_{}'.format(ax, band)] = '{}_base_SdssShape_psf_{}'.format(band, ax)
+                modifiers['I{}_pixel_{}'.format(ax, band)] = '{}_base_SdssShape_{}'.format(band, ax)
+                modifiers['I{}PSF_pixel_{}'.format(ax, band)] = '{}_base_SdssShape_psf_{}'.format(band, ax)
 
             modifiers['psf_fwhm_{}'.format(band)] = (
                 lambda xx, yy, xy: pixel_scale * 2.355 * (xx * yy - xy * xy) ** 0.25,
@@ -729,8 +729,8 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
         # cross-band average, second moment values
         modifiers['I_flag'] = 'ext_shapeHSM_HsmSourceMoments_flag'
         for ax in ['xx', 'yy', 'xy']:
-            modifiers[f'I{ax}'] = f'ext_shapeHSM_HsmSourceMoments_{ax}'
-            modifiers[f'I{ax}PSF'] = f'base_SdssShape_psf_{ax}'
+            modifiers[f'I{ax}_pixel'] = f'ext_shapeHSM_HsmSourceMoments_{ax}'
+            modifiers[f'I{ax}PSF_pixel'] = f'base_SdssShape_psf_{ax}'
 
         for band in bands:
             modifiers[f'psFlux_{band}'] = (convert_flux_to_nanoJansky,
@@ -768,8 +768,8 @@ class DC2ObjectParquetCatalog(DC2DMTractCatalog):
             modifiers[f'I_flag_{band}'] = f'{band}_base_SdssShape_flag'
 
             for ax in ['xx', 'yy', 'xy']:
-                modifiers[f'I{ax}_{band}'] = f'{band}_base_SdssShape_{ax}'
-                modifiers[f'I{ax}PSF_{band}'] = f'{band}_base_SdssShape_psf_{ax}'
+                modifiers[f'I{ax}_pixel_{band}'] = f'{band}_base_SdssShape_{ax}'
+                modifiers[f'I{ax}PSF_pixel_{band}'] = f'{band}_base_SdssShape_psf_{ax}'
 
             modifiers[f'psf_fwhm_{band}'] = (
                 lambda xx, yy, xy: pixel_scale * 2.355 * (xx * yy - xy * xy) ** 0.25,


### PR DESCRIPTION
This PR add `_pixel` postfix to I<xx,yy,xy> and family, as discussed in #397. This PR fixes #397.

@wmwv do you have preference between `Ixx_pixel_r` and `Ixx_r_pixel`? Currently I chose the former. 