### PR TITLE
Use MutableMapping for UserConfigManager

### DIFF
--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -23,8 +23,6 @@ _HERE = os.path.dirname(__file__)
 _CONFIG_DIRNAME = "catalog_configs"
 _CONFIG_DIRPATH = os.path.join(_HERE, _CONFIG_DIRNAME)
 _SITE_CONFIG_PATH = os.path.join(_HERE, "site_config", "site_rootdir.yaml")
-_USER_CONFIG_NAME = "gcr_catalogs.yaml"
-_ROOT_DIR_KEY = "root_dir"
 
 
 # yaml helper functions
@@ -80,7 +78,7 @@ def load_catalog_from_config_dict(catalog_config):
         catalog_config[Config.READER_KEY], __package__, BaseGenericCatalog
     )(**catalog_config)
 
-    
+
 # Classes
 
 class RootDirManager:
@@ -97,6 +95,7 @@ class RootDirManager:
     )
     _DICT_LIST_KEYS = ("catalogs",)
     _DESC_SITE_ENV = "DESC_GCR_SITE"
+    _ROOT_DIR_KEY = "root_dir"
     _NO_DEFAULT_ROOT_WARN = """
        Default root dir has not been set; catalogs may not be found.
        You can specify the site as an environment variable before you import GCRCatalogs,
@@ -122,11 +121,11 @@ class RootDirManager:
         self._site_info = self._get_site_info()
 
         # User config has highest priority
-        user_root_dir = self._user_config_manager.get_value(_ROOT_DIR_KEY)
+        user_root_dir = self._user_config_manager[self._ROOT_DIR_KEY]
         if user_root_dir:
             self._default_root_dir = user_root_dir
             return
-        
+
         if self._site_config_path:
             self._site_config = load_yaml_local(self._site_config_path)
             for k, v in self._site_config.items():
@@ -195,14 +194,14 @@ class RootDirManager:
         """
         Write current root_dir to user config
         """
-        self._user_config_manager.write_entries({_ROOT_DIR_KEY : os.path.abspath(self.root_dir)})
+        self._user_config_manager[self._ROOT_DIR_KEY] = os.path.abspath(self.root_dir)
 
     def unpersist_root_dir(self):
         """
         Remove root_dir entry from user config.  root_dir for the current
         session is unchanged, however.
         """
-        self._user_config_manager.remove_keys([_ROOT_DIR_KEY])
+        del self._user_config_manager[self._ROOT_DIR_KEY]
 
     def reset_root_dir(self):
         self._custom_root_dir = None
@@ -608,7 +607,7 @@ def remove_root_dir_default():
     Revert to state of no user default root dir
     """
     _config_register.unpersist_root_dir()
-    
+
 
 def get_site_list():
     """

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -121,7 +121,7 @@ class RootDirManager:
         self._site_info = self._get_site_info()
 
         # User config has highest priority
-        user_root_dir = self._user_config_manager[self._ROOT_DIR_KEY]
+        user_root_dir = self._user_config_manager.get(self._ROOT_DIR_KEY)
         if user_root_dir:
             self._default_root_dir = user_root_dir
             return
@@ -201,7 +201,10 @@ class RootDirManager:
         Remove root_dir entry from user config.  root_dir for the current
         session is unchanged, however.
         """
-        del self._user_config_manager[self._ROOT_DIR_KEY]
+        try:
+            del self._user_config_manager[self._ROOT_DIR_KEY]
+        except KeyError:
+            pass
 
     def reset_root_dir(self):
         self._custom_root_dir = None

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -12,7 +12,9 @@ from .user_config import UserConfigManager
 
 __all__ = [
     "get_root_dir", "set_root_dir", "remove_root_dir_default", "reset_root_dir", "get_available_catalogs",
-    "get_reader_list", "get_catalog_config", "has_catalog", "load_catalog", "retrieve_paths", "get_site_list", "set_root_dir_by_site"]
+    "get_reader_list", "get_catalog_config", "has_catalog", "load_catalog", "retrieve_paths", "get_site_list",
+    "set_root_dir_by_site"
+]
 
 _GITHUB_REPO = "LSSTDESC/gcr-catalogs"
 _GITHUB_URL = f"https://raw.githubusercontent.com/{_GITHUB_REPO}/master/GCRCatalogs"
@@ -23,6 +25,7 @@ _CONFIG_DIRPATH = os.path.join(_HERE, _CONFIG_DIRNAME)
 _SITE_CONFIG_PATH = os.path.join(_HERE, "site_config", "site_rootdir.yaml")
 _USER_CONFIG_NAME = "gcr_catalogs.yaml"
 _ROOT_DIR_KEY = "root_dir"
+
 
 # yaml helper functions
 
@@ -134,7 +137,6 @@ class RootDirManager:
         if not self._default_root_dir:
             site_string = ' '.join(self.site_list)
             warnings.warn(self._NO_DEFAULT_ROOT_WARN.format(self._DESC_SITE_ENV, site_string))
-
 
     def _get_site_info(self):
         """
@@ -563,7 +565,7 @@ class ConfigRegister(RootDirManager, ConfigManager):
     def root_dir(self, path):
         for config in self.configs:
             config.reset_resolved_content()
-        RootDirManager.root_dir.__set__(self,path)   # pylint: disable=no-member
+        RootDirManager.root_dir.__set__(self, path)  # pylint: disable=no-member
 
     def retrieve_paths(self, **kwargs):
         kwargs["names_only"] = False
@@ -607,6 +609,7 @@ def remove_root_dir_default():
     """
     _config_register.unpersist_root_dir()
     
+
 def get_site_list():
     """
     Return list of recognized sites
@@ -715,6 +718,8 @@ def retrieve_paths(name_startswith=None, name_contains=None, **kwargs):
     The format would be [(catalog_name, original_path, resolved_path), ...]
     """
     return _config_register.retrieve_paths(name_startswith=name_startswith, name_contains=name_contains, **kwargs)
-_config_register = ConfigRegister(_CONFIG_DIRPATH, _SITE_CONFIG_PATH,
-                                  _USER_CONFIG_NAME)
-print(get_root_dir())           # for debugging.  Delete this line before release
+
+
+_config_register = ConfigRegister(_CONFIG_DIRPATH, _SITE_CONFIG_PATH)
+
+print(get_root_dir())  # FIXME: for debugging.  Delete this line before release

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -7,7 +7,7 @@ import yaml
 import requests
 import socket
 from GCR import BaseGenericCatalog
-from .utils import is_string_like, get_config_dir
+from .utils import is_string_like
 from .user_config import UserConfigManager
 
 __all__ = [

--- a/GCRCatalogs/user_config.py
+++ b/GCRCatalogs/user_config.py
@@ -39,7 +39,7 @@ class UserConfigManager(MutableMapping):
                 return
         os.makedirs(os.path.dirname(self._config_path), exist_ok=True)
         with open(self._config_path, mode='w') as f:
-            yaml.dump(config_dict, f, default_flow_style=False)
+            yaml.safe_dump(config_dict, f, default_flow_style=False)
 
     def _load_config(self):
         """

--- a/GCRCatalogs/user_config.py
+++ b/GCRCatalogs/user_config.py
@@ -36,7 +36,8 @@ class UserConfigManager(MutableMapping):
             try:
                 os.remove(self._config_path)
             except FileNotFoundError:
-                return
+                pass
+            return
         os.makedirs(os.path.dirname(self._config_path), exist_ok=True)
         with open(self._config_path, mode='w') as f:
             yaml.safe_dump(config_dict, f, default_flow_style=False)

--- a/GCRCatalogs/user_config.py
+++ b/GCRCatalogs/user_config.py
@@ -1,108 +1,65 @@
 import os
-import warnings
+from collections.abc import MutableMapping
 import yaml
 
 """
-Utility class for managing user config (a dict) persisted to a yaml file. 
+Utility class for managing user config (a dict) persisted to a yaml file.
 """
 
 all = ['UserConfigManager']
 
-def _load_yaml_local(yaml_file):
-    with open(yaml_file) as f:
-        return yaml.safe_load(f)
 
-class UserConfigManager():
-    def __init__(self, config_name):
-        self._config_name = config_name
+class UserConfigManager(MutableMapping):
+    _default_config_filename = "gcr-catalogs.yml"
+    _default_config_dirname = "lsstdesc"
 
-        def _get_config_dir(create=True):
-            if os.getenv("XDG_CONFIG_HOME"):                   # Unix
-                user_config_dir = os.getenv("XDG_CONFIG_HOME")	
-            elif os.getenv("LOCALAPPDATA"):                     # Win
-                user_config_dir = os.getenv("LOCALAPPDATA")
-            else:
-                user_config_dir = os.path.join(os.path.expanduser("~"), ".config")
+    def __init__(self, config_filename=None, config_dirname=None):
 
-            desc_config_dir = os.path.join(user_config_dir, "lsstdesc")
+        self._config_filename = os.path.basename(config_filename or self._default_config_filename)
+        self._config_dirname = os.path.basename(config_dirname or self._default_config_dirname)
+        self._user_config_home = self._get_user_config_home()
+        self._config_path = os.path.join(self._user_config_home, self._config_dirname, self._config_filename)
 
-            if create:
-                os.makedirs(desc_config_dir, exist_ok=True)
+    @staticmethod
+    def _get_user_config_home():
+        if os.getenv("XDG_CONFIG_HOME"):                   # Unix
+            return os.getenv("XDG_CONFIG_HOME")
+        if os.getenv("LOCALAPPDATA"):                    # Win
+            return os.getenv("LOCALAPPDATA")
+        return os.path.join(os.path.expanduser("~"), ".config")
 
-            return desc_config_dir
-            
-        self._config_path = os.path.join(_get_config_dir(), config_name)
-
-
-    def user_config_exists(self):
-        return os.path.exists(self._config_path)
-
-    
-    def write_entries(self, entries, overwrite=False):
+    def _write_config(self, config_dict):
         """
-        Write one or more key-value pairs to the config file.  Create new file or
-        append to existing file. 
-
-        Parameters
-        ----------
-        entries     dict of entries to be written to file
-        overwrite   boolean.  If new keys overlap with old and overwrite is False, do
-                    nothing.  If True, new values prevail.
-
-        Returns
-        -------
-        dict written to the file.  
-        If overwrite condition is violated, return None
-
+        Low-level function to write config_dict to disk
         """
-        config_dict = {}
-
-        if self.user_config_exists():
-            config_dict = _load_yaml_local(self._config_path)
-            if not overwrite:
-                if not config_dict.keys().isdisjoint(entries.keys()):
-                    warnings.warn("Overwrite condition violated; config file not updated")
-                    return None
-
-        config_dict.update(entries)
-
+        os.makedirs(os.path.dirname(self._config_path), exist_ok=True)
         with open(self._config_path, mode='w') as f:
             f.write(yaml.dump(config_dict, default_flow_style=False))
 
-        return config_dict
-
-    
-    def remove_keys(self, keys):
+    def _load_config(self):
         """
-        Remove entries from config file
-
-        Parameters
-        ----------
-        A collection of keys
+        Low-level function to load config_dict from disk
         """
+        if os.path.isfile(self._config_path):
+            with open(self._config_path) as f:
+                return yaml.safe_load(f)
+        return dict()
 
-        if not self.user_config_exists():
-            return
+    def __getitem__(self, key):
+        return self._load_config()[key]
 
-        config_dict = _load_yaml_local(self._config_path)
-        for k in keys:
-            if k in config_dict.keys():
-                del config_dict[k]
+    def __setitem__(self, key, value):
+        config_dict = self._load_config()
+        config_dict[key] = value
+        self._write_config(config_dict)
 
-        if len(config_dict) == 0:
-            os.remove(self._config_path)
-        else:
-            with open(self._config_path, mode='w') as f:
-                f.write(yaml.dump(config_dict, default_flow_style=False))
+    def __delitem__(self, key):
+        config_dict = self._load_config()
+        del config_dict[key]
+        self._write_config(config_dict)
 
+    def __iter__(self):
+        return iter(self._load_config())
 
-    def get_value(self, key):
-        if not self.user_config_exists():
-            return None
-        
-        config_dict = _load_yaml_local(self._config_path)
-        if key in config_dict:
-            return config_dict[key]
-        else:
-            return None
-    
+    def __len__(self):
+        return len(self._load_config())

--- a/GCRCatalogs/user_config.py
+++ b/GCRCatalogs/user_config.py
@@ -22,7 +22,7 @@ class UserConfigManager(MutableMapping):
 
     @staticmethod
     def _get_user_config_home():
-        if os.getenv("XDG_CONFIG_HOME"):                   # Unix
+        if os.getenv("XDG_CONFIG_HOME"):                 # Unix
             return os.getenv("XDG_CONFIG_HOME")
         if os.getenv("LOCALAPPDATA"):                    # Win
             return os.getenv("LOCALAPPDATA")
@@ -32,17 +32,24 @@ class UserConfigManager(MutableMapping):
         """
         Low-level function to write config_dict to disk
         """
+        if not config_dict:
+            try:
+                os.remove(self._config_path)
+            except FileNotFoundError:
+                return
         os.makedirs(os.path.dirname(self._config_path), exist_ok=True)
         with open(self._config_path, mode='w') as f:
-            f.write(yaml.dump(config_dict, default_flow_style=False))
+            yaml.dump(config_dict, f, default_flow_style=False)
 
     def _load_config(self):
         """
         Low-level function to load config_dict from disk
         """
-        if os.path.isfile(self._config_path):
+        try:
             with open(self._config_path) as f:
                 return yaml.safe_load(f)
+        except FileNotFoundError:
+            pass
         return dict()
 
     def __getitem__(self, key):

--- a/GCRCatalogs/utils.py
+++ b/GCRCatalogs/utils.py
@@ -4,7 +4,8 @@ utility module
 import hashlib
 import os
 
-__all__ = ['md5', 'is_string_like', 'first', 'decode', 'get_config_dir']
+__all__ = ['md5', 'is_string_like', 'first', 'decode']
+
 
 def md5(fname, chunk_size=65536):
     """
@@ -34,22 +35,6 @@ def first(iterable, default=None):
     """
     return next(iter(iterable), default)
 
-  
-def get_config_dir(create=False):
-    if os.getenv("XDG_CONFIG_HOME"):                   # Unix
-        user_config_dir = os.getenv("XDG_CONFIG_HOME")
-    elif os.getenv("LOCALAPPDATA"):                     # Win
-        user_config_dir = os.getenv("LOCALAPPDATA")
-    else:
-        user_config_dir = os.path.join(os.path.expanduser("~"), ".config")
-
-    desc_config_dir = os.path.join(user_config_dir, "lsstdesc")
-
-    if create:
-        os.makedirs(desc_config_dir, exist_ok=True)
-
-    return desc_config_dir
-      
 
 def decode(bytestring):
     """


### PR DESCRIPTION
@JoanneBogart --- I am reviewing #503 and wanted to suggest that we use the abstract class `MutableMapping` for `UserConfigManager`. I made this PR (into your branch) to make my suggestion more specific. 

In particular, `UserConfigManager` behaves like a python dictionary, so we should keep the API as similar to that of a python dictionary as possible. The custom methods (`get_value`, `write_entries`,  `remove_keys`), although well-documented, are new names we are introducing for existing python syntax (and with slightly different behaviors, requiring the users to learn how to use these custom methods). Use `MutableMapping` as the base class resolves this issue by allowing users to use syntax that they are already familiar with the native python dictionary. 

The remaining changes in the PR are just space conventions. 
