### PR TITLE
Add Code of Couduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # DESC Code of Conduct
 
 All participants in the [LSSTDESC/gcr-catalogs](https://github.com/LSSTDESC/gcr-catalogs) repository, 
-regardless of their DESC membership, are expected to to abide by the 
+regardless of their DESC membership, are expected to abide by the 
 [DESC Code of Conduct](https://lsstdesc.org/assets/pdf/policies/LSST_DESC_Professional_Conduct.pdf).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# DESC Code of Conduct
+
+All participants in the [LSSTDESC/gcr-catalogs](https://github.com/LSSTDESC/gcr-catalogs) repository, 
+regardless of their DESC membership, are expected to to abide by the 
+[DESC Code of Conduct](https://lsstdesc.org/assets/pdf/policies/LSST_DESC_Professional_Conduct.pdf).


### PR DESCRIPTION
In anticipation of possible future participation of non-DESC members in this repo, I propose that we add a Code of Conduct to this repo, which can simply refer to [DESC Code of Conduct](https://lsstdesc.org/assets/pdf/policies/LSST_DESC_Professional_Conduct.pdf). 