### PR TITLE
Improve parquet reading performance/memory usage for arrow 0.16+

### DIFF
--- a/GCRCatalogs/parquet.py
+++ b/GCRCatalogs/parquet.py
@@ -4,7 +4,7 @@ import re
 __all__ = ['ParquetFileWrapper']
 
 
-def _retrive_data_from_arrow_table(table, as_dict=False):
+def _retrieve_data_from_arrow_table(table, as_dict=False):
     try:
         # Options introdcued in arrow 0.16+ to improve speed and memory usage
         df = table.to_pandas(split_blocks=True, self_destruct=True)
@@ -87,7 +87,7 @@ class ParquetFileWrapper():
 
         '''
         table = self.handle.read(columns=columns)
-        return _retrive_data_from_arrow_table(table, as_dict=as_dict)
+        return _retrieve_data_from_arrow_table(table, as_dict=as_dict)
 
     def read_columns_row_group(self, columns, as_dict=False):
         '''
@@ -104,7 +104,7 @@ class ParquetFileWrapper():
         dict or dataframe   See as_dict parameter above
         '''
         table = self.handle.read_row_group(self.current_row_group, columns=columns)
-        return _retrive_data_from_arrow_table(table, as_dict=as_dict)
+        return _retrieve_data_from_arrow_table(table, as_dict=as_dict)
 
     @property
     def info(self):

--- a/GCRCatalogs/parquet.py
+++ b/GCRCatalogs/parquet.py
@@ -3,6 +3,20 @@ import re
 
 __all__ = ['ParquetFileWrapper']
 
+
+def _retrive_data_from_arrow_table(table, as_dict=False):
+    try:
+        # Options introdcued in arrow 0.16+ to improve speed and memory usage
+        df = table.to_pandas(split_blocks=True, self_destruct=True)
+    except TypeError:
+        df = table.to_pandas()
+
+    if as_dict:
+        return {col: arr.values for col, arr in df.iteritems()}
+
+    return df
+
+
 class ParquetFileWrapper():
     '''
     Provide services commonly needed when catalog consists of one or more parquet files.
@@ -17,7 +31,6 @@ class ParquetFileWrapper():
     In the latter case _iter_native_dataset will have to iterate over row groups as well
     as files.  See reader dc2_truth_parquet.py for an example.
     The two methods are equivalent for files having only a single row group.
-        
     '''
     def __init__(self, file_path, info=None):
         '''
@@ -67,16 +80,14 @@ class ParquetFileWrapper():
         ----------
         columns   list of columns to be read
         as_dict   boolean.  If true, return data as dict where keys are column names
-                            Else return pandas dataframe 
-        returns
+                            Else return pandas dataframe
+        Returns
         -------
         dict or dataframe   See as_dict parameter above
 
         '''
-        d = self.handle.read(columns=columns).to_pandas()
-        if as_dict:
-            return {c: d[c].values for c in columns}
-        return d
+        table = self.handle.read(columns=columns)
+        return _retrive_data_from_arrow_table(table, as_dict=as_dict)
 
     def read_columns_row_group(self, columns, as_dict=False):
         '''
@@ -87,16 +98,13 @@ class ParquetFileWrapper():
         ----------
         columns   list of columns to be read
         as_dict   boolean.  If true, return data as dict where keys are column names
-                            Else return pandas dataframe 
-        returns
+                            Else return pandas dataframe
+        Returns
         -------
         dict or dataframe   See as_dict parameter above
         '''
-        d = self.handle.read_row_group(self.current_row_group, columns=columns).to_pandas()
-        if as_dict:
-            return {c: d[c].values for c in columns}
-        return d
-        
+        table = self.handle.read_row_group(self.current_row_group, columns=columns)
+        return _retrive_data_from_arrow_table(table, as_dict=as_dict)
 
     @property
     def info(self):
@@ -113,3 +121,6 @@ class ParquetFileWrapper():
             self._columns = [col for col in self.handle.schema.to_arrow_schema().names
                              if re.match(r'__\w+__$', col) is None]
         return list(self._columns)
+
+    def __getitem__(self, key):
+        return self.read_columns([key], as_dict=True)[key]


### PR DESCRIPTION
This PR improves parquet reading performance/memory usage for arrow 0.16.0+. 

In arrow 0.16.0+, two new options `split_blocks` and `self_destruct` are introduced to `to_pandas` -- the first option allows better performance by introducing zero-copy opportunity, and the second option ensures unused references are deleted for garbage collection to reclaim memory (cf. https://github.com/apache/arrow/pull/6067).

Adding these option to our parquet wrapper improves performance/memory usage. Backward (for arrow <0.16.0) compatibility is maintained. 

This PR has been tested locally and is ready for review.