### PR TITLE
Bug fix in truth match catalog

### DIFF
--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -50,7 +50,9 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
 
         self._as_object_addon = bool(kwargs.get("as_object_addon"))
         self._as_truth_table = bool(kwargs.get("as_truth_table"))
-        self._as_matchdc2_schema = self._as_object_addon = bool(kwargs.get("as_matchdc2_schema"))
+        self._as_matchdc2_schema = bool(kwargs.get("as_matchdc2_schema"))
+        if self._as_matchdc2_schema:
+            self._as_object_addon = True
 
         if self._as_object_addon and self._as_truth_table:
             raise ValueError("Reader options `as_object_addon` and `as_truth_table` cannot both be set to True.")


### PR DESCRIPTION
A bug was introduced in #513 when I added the `as_matchdc2_schema` option:

When `as_matchdc2_schema` is set to True in the config, both `self._as_matchdc2_schema` and `self._as_object_addon` should be set to True. 

However, when `as_matchdc2_schema` is set to False or not set in the config, only `self._as_matchdc2_schema` should be set to False, and `self._as_object_addon` should be left unchanged. In #513 I accidentally set `self._as_object_addon` to False too.

This PR fixes this logical bug. 