### PR TITLE
Make get_quantity_info work with "_truth" postfix in truth-match add-on

### DIFF
--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -143,6 +143,8 @@ class DC2DMCatalog(BaseGenericCatalog):
 
         if self.META_PATH:
             self._quantity_info_dict = self._generate_info_dict(self.META_PATH, bands)
+        else:
+            self._quantity_info_dict = dict()
 
         self._len = None
 

--- a/GCRCatalogs/dc2_truth_match.py
+++ b/GCRCatalogs/dc2_truth_match.py
@@ -158,3 +158,16 @@ class DC2TruthMatchCatalog(DC2DMTractCatalog):
                     col,
                     "{}_match_mask".format(t),
                 )
+
+    def _get_quantity_info_dict(self, quantity, default=None):
+        """
+        Befere calling the parent method, check if `quantity` has an added "_truth" postfix
+        due to the `if self._as_object_addon:...` part in _subclass_init. If so, remove the postfix.
+        """
+        if (
+            quantity not in self._quantity_info_dict and
+            quantity in self._quantity_modifiers and
+            quantity.endswith("_truth")
+        ):
+            quantity = quantity[:-6]
+        return super()._get_quantity_info_dict(quantity, default)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     keywords='GCR',
     packages=['GCRCatalogs'],
-    install_requires=['requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.9.1'],
+    install_requires=['requests', 'pyyaml', 'numpy', 'astropy', 'GCR>=0.9.2'],
     extras_require={
         'full': ['h5py', 'healpy', 'pandas', 'pyarrow', 'tables'],
     },


### PR DESCRIPTION
In the truth-match add-on catalog (i.e., when `as_object_addon` set to True), most columns are postfixed with `_truth` to distinguish them from the object columns ([code](https://github.com/LSSTDESC/gcr-catalogs/blob/d21ca7c66e95119f685faac9499585cdb386d7eb/GCRCatalogs/dc2_truth_match.py#L69)). However, this would resulting in code like:

```python
cat.get_quantity_info("mag_r_noMW_truth")
```

not working, as `mag_r_noMW_truth` is not a known quantity in the quantity info dictionary (which, in this case, was obtained from the meta yaml file). 

This PR overwrites the `_get_quantity_info_dict` method by adding a check before calling the parent method, and removes "_truth" postfix when the quantity does not appear in the info dictionary but does appear in quantity modifier. 