### PR TITLE
Allow catalog config to overwrite `meta_path` for DC2DMCatalog

### DIFF
--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -141,8 +141,11 @@ class DC2DMCatalog(BaseGenericCatalog):
 
             self._quantity_modifiers = self._generate_modifiers(**quantity_modifiers_kwargs)
 
-        if self.META_PATH:
-            self._quantity_info_dict = self._generate_info_dict(self.META_PATH, bands)
+        # meta_path in catalog config take precedence, otherwise use the class default value
+        meta_path = kwargs.get("meta_path", self.META_PATH)
+        if meta_path:
+            meta_path = os.path.join(self.FILE_DIR, meta_path)  # for relative meta_path
+            self._quantity_info_dict = self._generate_info_dict(meta_path, bands)
         else:
             self._quantity_info_dict = dict()
 

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -91,6 +91,7 @@ class RootDirManager:
         "header_file",
         "repo",
         "table_dir",
+        "meta_path",
     )
     _DICT_LIST_KEYS = ("catalogs",)
     _DESC_SITE_ENV = "DESC_GCR_SITE"


### PR DESCRIPTION
As discussed in https://github.com/LSSTDESC/gcr-catalogs/pull/518#discussion_r546399824 -- for `DC2DMCatalog` and subclasses, if `meta_path` appears in the catalog config, it should overwrite the class default value (`self.META_PATH`). This PR implements this feature. We allows three ways to specify the meta file path in catalog config:

```yaml
meta_path: ^/meta_path/relative/to/shared_dir
meta_path: meta_path/relative/to/reader_path
meta_path: /absolute/meta_path
```