### PR TITLE
add helper functions for tract catalogs

### DIFF
--- a/GCRCatalogs/helpers/base_filters.py
+++ b/GCRCatalogs/helpers/base_filters.py
@@ -1,0 +1,69 @@
+"""
+Base filters. To be called by high-level helper functions that are specific
+to catalog types (e.g., tract catalogs).
+"""
+
+import numpy as np
+
+from GCR import GCRQuery
+
+__all__ = ["partition_filter", "sample_filter"]
+
+
+def partition_filter(name, ids, id_high=None):
+    """
+    Returns a GCRQuery object to be used in the `native_filters` argument of get_quantities(),
+    to select a subset of partitions. Partitions must have integer IDs.
+
+    If *ids* is a single integer, select only that partition.
+    If *ids* and *id_high* are both given as single integers, select [ids, id_high]
+    (inclusive on both ends!).
+    If *ids* is a list, select partitions in that list (*id_high* is ignored).
+    """
+    if isinstance(ids, int):
+        if id_high is None:
+            return GCRQuery(f"{name} == {ids}")
+        elif isinstance(id_high, int):
+            return GCRQuery(f"{name} >= {ids}", f"{name} <= {id_high}")
+        raise ValueError(f"When `{name}s` is an integer, `{name}_high` must be an integer or None.")
+
+    ids = np.unique(np.asarray(ids, dtype=np.int))
+    if not ids.size:
+        raise ValueError(f"Must select at least one {name}.")
+
+    def _partition_selector(partition_ids, ids_to_select=ids):
+        return np.isin(partition_ids, ids_to_select, assume_unique=True)
+
+    return GCRQuery((_partition_selector, name))
+
+
+def sample_filter(ref_col_name, frac, random_state=None):
+    """
+    Returns a GCRQuery object to be used in the `filters` argument of get_quantities()
+    to randomly sample the object catalog by a given fraction (*frac*).
+
+    *ref_col_name* must be a column of integer values.
+
+    Optionally, provide *random_state* (int or np.random.RandomState) to fix random state.
+    """
+    # pylint: disable=no-member
+
+    frac = float(frac)
+    if frac > 1 or frac < 0:
+        raise ValueError("`frac` must be a float number in [0, 1].")
+    if frac == 1:
+        return GCRQuery()
+    if frac == 0:
+        return GCRQuery((lambda a: np.zeros_like(a, dtype=np.bool), "tract"))
+
+    if not isinstance(random_state, np.random.RandomState):
+        random_state = np.random.RandomState(random_state)
+    seed = random_state.randint(2**32)
+
+    def _sampler(arr, frac=frac, seed=seed):
+        size = len(arr)  # arr is a numpy array of integers
+        if size:
+            return np.random.RandomState((int(arr[0]) + seed) % (2**32)).rand(size) < frac
+        return np.zeros(0, dtype=np.bool)
+
+    return GCRQuery((_sampler, ref_col_name))

--- a/GCRCatalogs/helpers/tract_catalogs.py
+++ b/GCRCatalogs/helpers/tract_catalogs.py
@@ -59,7 +59,7 @@ def sample_filter(frac, random_state=None):
     def _sampler(tract_arr, frac=frac, seed=seed):
         size = len(tract_arr)  # tract_arr is a numpy array of tract IDs
         if size:
-            return np.random.RandomState(tract[0] + seed).rand(size) < frac
+            return np.random.RandomState(tract_arr[0] + seed).rand(size) < frac
         return np.zeros(0, dtype=np.bool)
 
     return GCRQuery((_sampler, "tract"))

--- a/GCRCatalogs/helpers/tract_catalogs.py
+++ b/GCRCatalogs/helpers/tract_catalogs.py
@@ -56,8 +56,8 @@ def sample_filter(frac, random_state=None):
         random_state = np.random.RandomState(random_state)
     seed = random_state.randint(65536)
 
-    def _sampler(tract, frac=frac, seed=seed):
-        size = len(tract)
+    def _sampler(tract_arr, frac=frac, seed=seed):
+        size = len(tract_arr)  # tract_arr is a numpy array of tract IDs
         if size:
             return np.random.RandomState(tract[0] + seed).rand(size) < frac
         return np.zeros(0, dtype=np.bool)

--- a/GCRCatalogs/helpers/tract_catalogs.py
+++ b/GCRCatalogs/helpers/tract_catalogs.py
@@ -1,10 +1,7 @@
 """
 Helper functions for tract catalogs.
 """
-
-import numpy as np
-
-from GCR import GCRQuery
+from . import base_filters
 
 __all__ = ["tract_filter", "sample_filter"]
 
@@ -18,21 +15,7 @@ def tract_filter(tracts, tract_high=None):
     If *tracts* and *tract_high* are both given as single integers, select [tracts, tract_high]
     (inclusive on both ends!).
     """
-    if isinstance(tracts, int):
-        if tract_high is None:
-            return GCRQuery('tract == {}'.format(tracts))
-        elif isinstance(tract_high, int):
-            return GCRQuery('tract >= {}'.format(tracts), 'tract <= {}'.format(tract_high))
-        raise ValueError("When `tracts` is an integer, `tract_high` must be an integer or None.")
-
-    tracts = np.unique(np.asarray(tracts, dtype=np.int))
-    if not tracts.size:
-        raise ValueError("Must select at least one tract.")
-
-    def _tract_selector(tract, tracts_to_select=tracts):
-        return np.in1d(tract, tracts_to_select, assume_unique=True)
-
-    return GCRQuery((_tract_selector, "tract"))
+    return base_filters.partition_filter("tract", tracts, tract_high)
 
 
 def sample_filter(frac, random_state=None):
@@ -42,24 +25,4 @@ def sample_filter(frac, random_state=None):
 
     Optionally, provide *random_state* (int or np.random.RandomState) to fix random state.
     """
-    # pylint: disable=no-member
-
-    frac = float(frac)
-    if frac > 1 or frac < 0:
-        raise ValueError("`frac` must be a float number in [0, 1].")
-    if frac == 1:
-        return GCRQuery()
-    if frac == 0:
-        return GCRQuery((lambda a: np.zeros_like(a, dtype=np.bool), "tract"))
-
-    if not isinstance(random_state, np.random.RandomState):
-        random_state = np.random.RandomState(random_state)
-    seed = random_state.randint(65536)
-
-    def _sampler(tract_arr, frac=frac, seed=seed):
-        size = len(tract_arr)  # tract_arr is a numpy array of tract IDs
-        if size:
-            return np.random.RandomState(tract_arr[0] + seed).rand(size) < frac
-        return np.zeros(0, dtype=np.bool)
-
-    return GCRQuery((_sampler, "tract"))
+    return base_filters.sample_filter("tract", frac, random_state)

--- a/GCRCatalogs/helpers/tract_catalogs.py
+++ b/GCRCatalogs/helpers/tract_catalogs.py
@@ -1,0 +1,65 @@
+"""
+Helper functions for tract catalogs.
+"""
+
+import numpy as np
+
+from GCR import GCRQuery
+
+__all__ = ["tract_filter", "sample_filter"]
+
+
+def tract_filter(tracts, tract_high=None):
+    """
+    Returns a GCRQuery object to be used in the `native_filters` argument of get_quantities(),
+    to select only the tracts in *tracts* (a list of integers).
+
+    If *tracts* is a single integer, select only that tract.
+    If *tracts* and *tract_high* are both given as single integers, select [tracts, tract_high]
+    (inclusive on both ends!).
+    """
+    if isinstance(tracts, int):
+        if tract_high is None:
+            return GCRQuery('tract == {}'.format(tracts))
+        elif isinstance(tract_high, int):
+            return GCRQuery('tract >= {}'.format(tracts), 'tract <= {}'.format(tract_high))
+        raise ValueError("When `tracts` is an integer, `tract_high` must be an integer or None.")
+
+    tracts = np.unique(np.asarray(tracts, dtype=np.int))
+    if not tracts.size:
+        raise ValueError("Must select at least one tract.")
+
+    def _tract_selector(tract, tracts_to_select=tracts):
+        return np.in1d(tract, tracts_to_select, assume_unique=True)
+
+    return GCRQuery((_tract_selector, "tract"))
+
+
+def sample_filter(frac, random_state=None):
+    """
+    Returns a GCRQuery object to be used in the `filters` argument of get_quantities()
+    to randomly sample the object catalog by a given fraction (*frac*).
+
+    Optionally, provide *random_state* (int or np.random.RandomState) to fix random state.
+    """
+    # pylint: disable=no-member
+
+    frac = float(frac)
+    if frac > 1 or frac < 0:
+        raise ValueError("`frac` must be a float number in [0, 1].")
+    if frac == 1:
+        return GCRQuery()
+    if frac == 0:
+        return GCRQuery((lambda a: np.zeros_like(a, dtype=np.bool), "tract"))
+
+    if not isinstance(random_state, np.random.RandomState):
+        random_state = np.random.RandomState(random_state)
+    seed = random_state.randint(65536)
+
+    def _sampler(tract, frac=frac, seed=seed):
+        size = len(tract)
+        if size:
+            return np.random.RandomState(tract[0] + seed).rand(size) < frac
+        return np.zeros(0, dtype=np.bool)
+
+    return GCRQuery((_sampler, "tract"))


### PR DESCRIPTION
This PR adds two helper functions for tract catalogs -- `tract_filter` and `sample_filter`. They are used in the tutorial notebooks for public release. Since they will be used in multiple notebooks and the users are likely to use them in their own script (if they follow the notebook), it seems that putting them into `GCRCatalogs` would be a better choice. 

Here, `tract_filter` and `sample_filter` return GCRQuery objects that can be used in the `native_filters` and `filters` arguments, respectively, of `get_quantities()`. They can help select specific tracts or down sample the rows at random. 