### PR TITLE
Fix typos/issues in the schema meta files

### DIFF
--- a/GCRCatalogs/catalog_configs/_dc2_object_meta.yaml
+++ b/GCRCatalogs/catalog_configs/_dc2_object_meta.yaml
@@ -15,8 +15,8 @@ tract: {"type": "int64", "unit": "none", "description": "Tract ID in Sky Map"}
 patch: {"type": "string", "unit": "none", "description": "Patch ID in Sky Map (as a string, `x,y`)"}
 Ixx_pixel: {"type": "float64", "unit": "sq. pixel", "description": "Adaptive second moment (xx) of source intensity, averaged across bands"}
 Ixx_pixel_<band>: {"type": "float64", "unit": "sq. pixel", "description": "Adaptive second moment (xx) of source intensity in <band>"}
-Iyy_pixel: {"type": "float64", "unit": "sq. pixel", "description": "Adaptive second moment (yy) of source intensity in <band>"}
-Iyy_pixel_<band>: {"type": "float64", "unit": "sq. pixel", "description": "Adaptive second moment (yy) of source intensity, averaged across bands"}
+Iyy_pixel: {"type": "float64", "unit": "sq. pixel", "description": "Adaptive second moment (yy) of source intensity, averaged across bands"}
+Iyy_pixel_<band>: {"type": "float64", "unit": "sq. pixel", "description": "Adaptive second moment (yy) of source intensity in <band>"}
 Ixy_pixel: {"type": "float64", "unit": "sq. pixel", "description": "Adaptive second moment (xy) of source intensity, averaged across bands"}
 Ixy_pixel_<band>: {"type": "float64", "unit": "sq. pixel", "description": "Adaptive second moment (xy) of source intensity in <band>"}
 I_flag: {"type": "bool", "unit": "none", "description": "Flag for issues with `Ixx`, `Iyy_pixel`, and `Ixy`"}

--- a/GCRCatalogs/catalog_configs/_dc2_truth_match_meta.yaml
+++ b/GCRCatalogs/catalog_configs/_dc2_truth_match_meta.yaml
@@ -1,5 +1,5 @@
 id: {"type": "string", "unit": "none", "description": "Unique object ID"}
-host_galaxy: {"type": "int64", "unit": "none", "description": "ID of the host galaxy for a SN entry (-1 for other truth types)"}
+host_galaxy: {"type": "int64", "unit": "none", "description": "ID of the host galaxy for a SN/AGN entry (-1 for other truth types)"}
 ra: {"type": "float64", "unit": "degree", "description": "Right Ascension"}
 dec: {"type": "float64", "unit": "degree", "description": "Declination"}
 redshift: {"type": "float32", "unit": "none", "description": "Redshift"}


### PR DESCRIPTION
This PRs fix minor typos/issues in the schema meta files (for object and truth catalog). Thanks to @rmandelb and @JoanneBogart for correcting them at the first place (in the draft release note). 