### PR TITLE
Add `public_release` keyword; adjust `get_available_catalogs` behavior accordingly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,7 @@ include_in_default_catalog_list: true
 addon_for: another_catalog_name
 deprecated: "A short deprecation message."
 is_pseudo_entry: true
+public_release: v1, v2
 ```
 
 The first two keywords allow you to reference another catalog:
@@ -73,6 +74,7 @@ The rest are mainly for documentation/informational purpose:
 - `addon_for` should _only_ be set to indicate that the catalog is intended to be used _only_ as an addon catalog for `another_catalog_name`, and is not for standalone use. Note that setting this keyword does not prohibit users from loading this catalog.
 - `deprecated` should _only_ be set to indicate that the catalog has been deprecated and should no longer be used. Deprecation message can include alternative catalogs that the users may use. Note that setting this keyword does not prohibit users from loading this catalog.
 - `is_pseudo_entry` should _only_ be set to indicate that the config is a pseudo entry (i.e., not intended to be loaded via GCR; no reader required). Pseudo entries will by default be ignored by the register.
+- `public_release` should _only_ be set to indicate that the config is a public release entry. It can be set to a string or a list of strings.
 
 ## GitHub workflow
 

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -127,14 +127,18 @@ class RootDirManager:
         # User config has highest priority
         user_root_dir = self._user_config_manager.get(self._ROOT_DIR_KEY)
         if user_root_dir:
-            self._default_root_dir = user_root_dir
-            return
+            self._root_dir_from_config = user_root_dir
 
-        if self._site_config_path:
+        # Try to set self._root_dir_from_site
+        if self._site_config_path and os.path.isfile(self._site_config_path):
             self._site_config = load_yaml_local(self._site_config_path)
+
+        if self._site_config:
+            site_info = self._get_site_info()
+            if site_info:
             for k, v in self._site_config.items():
-                if k in self._site_info:
-                    self._default_root_dir = v
+                    if k in site_info:
+                        self._root_dir_from_site = v
                     break
 
     def _get_site_info(self):

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -245,7 +245,7 @@ class RootDirManager:
                     try:
                         resolved_path = os.path.join(self.root_dir, orig_path[len(self._ROOT_DIR_SIGNAL):])
                     except TypeError:
-                        warnings.warn("Root dir has not been set!")
+                        pass
                     else:
                         config_dict[k] = resolved_path
                 if record is not None:

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -214,11 +214,8 @@ class RootDirManager:
         """
         Remove root_dir item from user config.  root_dir for the current
         session is unchanged, however.
-        Returns
-        -------
-        old value (may be None)
         """
-        return self._user_config_manager.pop(self._ROOT_DIR_KEY, None)
+        self._user_config_manager.pop(self._ROOT_DIR_KEY, None)
 
     def reset_root_dir(self):
         self._custom_root_dir = None

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -734,7 +734,7 @@ def get_public_catalog_names(
     **kwargs
 ):
     """
-    Returns a list of all available catalog names.
+    Returns a list of names of all available catalog satisfying any constraints specified in parameters.
 
     Parameters
     ----------

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -740,7 +740,7 @@ def get_public_catalog_names(
     ----------
     include_default_only: bool, optional (default: True)
         When set to False, returned list will include catalogs that are not in the default listing
-        (i.e., those may not be suitable for general comsumption)
+        (i.e., those which may not be suitable for general consumption)
     name_startswith: str, optional (default: None)
         If set, only return catalogs whose name starts with *name_startswith*
     name_contains: str, optional (default: None)

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -711,7 +711,7 @@ def get_available_catalog_names(
     ----------
     include_default_only: bool, optional (default: True)
         When set to False, returned list will include catalogs that are not in the default listing
-        (i.e., those may not be suitable for general comsumption)
+        (i.e., those which may not be suitable for general consumption)
     name_startswith: str, optional (default: None)
         If set, only return catalogs whose name starts with *name_startswith*
     name_contains: str, optional (default: None)

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -142,12 +142,15 @@ class RootDirManager:
         Return a string which, when executing at a recognized site with
         well-known name, will include the name for that site
         """
-        site_from_env = os.getenv(self._DESC_SITE_ENV)
+        site_from_env = os.getenv(self._DESC_SITE_ENV, "")
         site_from_socket = socket.getfqdn()
+
+        # hack for nersc batch nodes
+        if site_from_socket.startswith("nid") and site_from_socket[3:].isdigit():
+            site_from_socket += ".nersc.gov"
+
         if site_from_env:
-            if site_from_socket and site_from_env not in site_from_socket and not (
-                site_from_env == "nersc" and site_from_socket.startswith("nid")
-            ):
+            if site_from_socket and site_from_env not in site_from_socket:
                 warnings.warn("Site determined from env variable {} = {}, which differs from node name {}".format(
                     self._DESC_SITE_ENV, site_from_env, site_from_socket
                 ))

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -684,9 +684,9 @@ def get_available_catalogs(
         If set, only return catalogs whose name contains with *name_contains*
     """
     if not kwargs.get("is_public_release") and not _config_register.has_valid_root_dir_in_site_config:
-        warnings.warn("""It appears that you do not have access to DESC default root dir, or you are using a customized root dir.
+        warnings.warn("""It appears that you do not have access to the default root dir at a recognized DESC site, or you are using a customized root dir.
 As such, the returned catalogs may not all be available to you.
-Use get_public_catalog_names to see catalogs to see a list of catalogs from public releases.
+Use get_public_catalog_names to see a list of catalogs from public releases only.
 If you are a DESC member and believe you are getting this warning by mistake, please contact DESC help.""")
     kwargs.setdefault("resolve_content", (not names_only))
     return _config_register.get_configs(

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -715,7 +715,7 @@ def get_available_catalog_names(
     name_startswith: str, optional (default: None)
         If set, only return catalogs whose name starts with *name_startswith*
     name_contains: str, optional (default: None)
-        If set, only return catalogs whose name contains with *name_contains*
+        If set, only return catalogs whose name contains *name_contains*
     """
     kwargs["names_only"] = False
     return get_available_catalogs(

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -744,7 +744,7 @@ def get_public_catalog_names(
     name_startswith: str, optional (default: None)
         If set, only return catalogs whose name starts with *name_startswith*
     name_contains: str, optional (default: None)
-        If set, only return catalogs whose name contains with *name_contains*
+        If set, only return catalogs whose name contains *name_contains*
     public_release_name: str, optional (default: None)
         If set, only return catalogs that are part of *public_release_name*
     """

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -681,10 +681,8 @@ def get_available_catalogs(
     name_contains: str, optional (default: None)
         If set, only return catalogs whose name contains with *name_contains*
     """
-    if "resolve_content" not in kwargs:
-        kwargs["resolve_content"] = (not names_only)
-    if "is_public_release" not in kwargs and not _config_register.has_root_dir_from_site:
-        kwargs["is_public_release"] = True
+    kwargs.setdefault("resolve_content", (not names_only))
+    kwargs.setdefault("is_public_release", (not _config_register.has_root_dir_from_site))
     return _config_register.get_configs(
         names_only=names_only,
         include_default_only=include_default_only,
@@ -713,9 +711,9 @@ def get_available_catalog_names(
     name_contains: str, optional (default: None)
         If set, only return catalogs whose name contains with *name_contains*
     """
+    kwargs["names_only"] = False
     return get_available_catalogs(
         include_default_only=include_default_only,
-        names_only=True,
         name_startswith=name_startswith,
         name_contains=name_contains,
         **kwargs

--- a/GCRCatalogs/register.py
+++ b/GCRCatalogs/register.py
@@ -197,10 +197,12 @@ class RootDirManager:
         If *site* is a recognized site, set root_dir to corresponding value
         """
         try:
-            self.root_dir = self._site_config[site]
+            new_root_dir = self._site_config[site]
         except KeyError:
-            site_string = ' '.join(_config_register.site_list)
+            site_string = ' '.join(self.site_list)
             warnings.warn(f"Unknown site '{site}'.\nAvailable sites are: {site_string}\nroot_dir is unchanged")
+        else:
+            self.root_dir = new_root_dir
 
     def persist_root_dir(self):
         """


### PR DESCRIPTION
This PR tries to fix #501. In particular it adds the following features:

- Recognize the `public_release` keyword in catalog configs.
- `get_available_catalogs` now accepts `is_public_release` argument; it has three operation modes:

  ```python
  # returns all catalogs that have `public_release`
  get_available_catalogs(is_public_release=True)
  
  # excludes all catalogs that have `public_release` 
  get_available_catalogs(is_public_release=False) 

  # returns all catalogs that have `public_release` and its value *contains* "v1"
  get_available_catalogs(is_public_release="v1")  
  ``` 

- Add `get_available_catalog_names`, which is a shorthand for `get_available_catalogs(names_only=True)`.

- If the user does not have `root_dir` set by site, `get_available_catalogs()` defaults to `get_available_catalogs(is_public_release=True)`. Otherwise, it defaults to `is_public_release=False`. Users can supply `is_public_release` keyword argument to overwrite.

In order to implement the last bullet point, I had to make some adjustment to `RootDirManager`. Specifically, I now distinguish:

```python
self._root_dir_from_runtime
self._root_dir_from_config
self._root_dir_from_site
```

This order is the order in which `root_dir` will be determined. In this way, we can use `self._root_dir_from_site` to determined if the user is a potential DESC member. A `has_root_dir_from_site` property was added `RootDirManager` for this purpose. 

During tests I notices a few places where an error may be raise due to None / empty string confusion. I've fixed those in this PR too. 

@JoanneBogart you may have some thoughts/opinions on the implementation details and I welcome your comments. 