### PR TITLE
Bug fix: allow non-string values in `info_dict`

### DIFF
--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -16,7 +16,7 @@ import yaml
 from GCR import BaseGenericCatalog
 from .parquet import ParquetFileWrapper
 
-from .utils import first
+from .utils import first, is_string_like
 
 __all__ = ['DC2DMCatalog', 'DC2DMTractCatalog', 'DC2DMVisitCatalog']
 
@@ -200,7 +200,9 @@ class DC2DMCatalog(BaseGenericCatalog):
 
             if bands and "<band>" in q:
                 for band in bands:
-                    info_dict[q.replace("<band>", band)] = {k: v.replace("<band>", band) for k, v in info.items()}
+                    info_dict[q.replace("<band>", band)] = {
+                        k: v.replace("<band>", band) if is_string_like(v) else v for k, v in info.items()
+                    }
             else:
                 info_dict[q] = info
 


### PR DESCRIPTION
In the updated `_generate_info_dict` method, all values in the `info_dict` that contains `<band>` will be replaced by the actually band name. However, not all values in `info_dict` are string. Hence, a check should be done before invoking the `.replace` method. 

This bug was discovered when I ran the full test suite for the upcoming v1.1.0 tag.