### PR TITLE
Add dc2_object_run2.2i_dr6_v2pre

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2pre.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2pre.yaml
@@ -1,0 +1,6 @@
+subclass_name: dc2_object.DC2ObjectParquetCatalog
+base_dir: ^/DC2-prod/Run2.2i/dpdd/Run2.2i-dr6-v2pre/object_table_summary
+pixel_scale: 0.2
+
+description: DC2 Run 2.2i DR6 Object Table v2 pre-release
+creators: ['DESC DC2 Team']

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2pre_with_addons.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2pre_with_addons.yaml
@@ -1,0 +1,15 @@
+subclass_name: composite.CompositeReader
+catalogs:
+  - catalog_name: dc2_object_run2.2i_dr6_v2pre
+  - subclass_name: dc2_metacal.DC2MetacalCatalog
+    base_dir: ^/DC2-prod/Run2.2i/dpdd/Run2.2i-dr6-wfd-v2pre/metacal_table_summary
+    bands: griz
+    apply_metacal_test3_fix: true
+    matching_partition: true
+    matching_row_order: true
+    overwrite_quantities: false
+    overwrite_attributes: false
+    include_native_quantities: true
+
+description: DC2 Run 2.2i DR6 Object Table v2 pre-release with all available add-ons (currently only metacal)
+creators: ['DESC DC2 Team']


### PR DESCRIPTION
This PR adds the catalog config for `dc2_object_run2.2i_dr6_v2pre` and resolves #534. 