### PR TITLE
Improve user config prompt

### DIFF
--- a/GCRCatalogs/user_config.py
+++ b/GCRCatalogs/user_config.py
@@ -38,6 +38,6 @@ if __name__ == "__main__":
             old = umgr.get(args.key)
             umgr[args.key] = args.value
             if old:
-                print(f"New value {args.value} was set. Old value was {old}")
+                print(f"{args.key} is now set to {args.value}\nOld value was {old}")
             else:
-                print(f"New value {args.value} was set. No old value or old value was None")
+                print(f"{args.key} is now set to {args.value}\nNo old value or old value was None")


### PR DESCRIPTION
When using `python -m GCRCatalogs.user_config set root_dir /path/`, the prompt would said `New value /path/ was set` which is a bit unclear since it is `root_dir` being set. This PR changes the prompt to `root_dir is now set to /path/`.