### PR TITLE
Add cosmoDC2 public configs

### DIFF
--- a/GCRCatalogs/catalog_configs/desc_cosmodc2.yaml
+++ b/GCRCatalogs/catalog_configs/desc_cosmodc2.yaml
@@ -1,0 +1,3 @@
+alias: desc_cosmodc2_v1.1.4
+include_in_default_catalog_list: true
+public_release: cosmodc2

--- a/GCRCatalogs/catalog_configs/desc_cosmodc2_v1.1.4.yaml
+++ b/GCRCatalogs/catalog_configs/desc_cosmodc2_v1.1.4.yaml
@@ -1,0 +1,19 @@
+subclass_name: cosmodc2.CosmoDC2GalaxyCatalog
+catalog_root_dir: ^/lsstdesc-public/dc2/cosmoDC2_v1.1.4
+catalog_filename_template: z_{}_{}.step_all.healpix_{}.hdf5
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+version: "1.1.4"
+check_md5: false
+check_size: false
+check_file_list_complete: false
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
+description: This is the extra-galactic catalog for the LSST-DESC data challenge DC2.
+public_release: cosmodc2


### PR DESCRIPTION
This PR adds public configs for the cosmoDC2 catalog. @heather999, can you verify that `catalog_root_dir` matches the endpoint setting? Thanks!