### PR TITLE
add parquet versions of cosmoDC2 and SkySim5000

### DIFF
--- a/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_parquet.yaml
+++ b/GCRCatalogs/catalog_configs/cosmoDC2_v1.1.4_parquet.yaml
@@ -1,0 +1,16 @@
+subclass_name: cosmodc2_parquet.CosmoDC2ParquetCatalog
+base_dir: ^/xgal/cosmoDC2/cosmoDC2_v1.1.4_parquet
+filename_pattern: 'cosmoDC2_v1.1.4_image_healpix{healpix_pixel}.parquet$'
+
+version: "1.1.4"
+sky_area: 439.78987
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
+description: |
+    This is the extra-galactic catalog for the LSST-DESC data challenge DC2 in Parquet format.

--- a/GCRCatalogs/catalog_configs/skysim5000_v1.1.1_parquet.yaml
+++ b/GCRCatalogs/catalog_configs/skysim5000_v1.1.1_parquet.yaml
@@ -14,5 +14,3 @@ cosmology:
 creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
 description: |
     This is the 5000 sq. deg. extra-galactic catalog for LSST DESC in Parquet format
-
-include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/skysim5000_v1.1.1_parquet.yaml
+++ b/GCRCatalogs/catalog_configs/skysim5000_v1.1.1_parquet.yaml
@@ -1,0 +1,18 @@
+subclass_name: cosmodc2_parquet.CosmoDC2ParquetCatalog
+base_dir: ^/xgal/skysim/skysim5000_v1.1.1_parquet
+filename_pattern: 'skysim5000_v1.1.1_healpix{healpix_pixel}.parquet$'
+
+version: "1.1.1"
+sky_area: 5264.05
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+creators: ['Andrew Hearin', 'Danila Korytov', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Joe Hollowed', 'Andrew Benson', 'Katrin Heitmann']
+description: |
+    This is the 5000 sq. deg. extra-galactic catalog for LSST DESC in Parquet format
+
+include_in_default_catalog_list: true

--- a/GCRCatalogs/cosmodc2_parquet.py
+++ b/GCRCatalogs/cosmodc2_parquet.py
@@ -1,0 +1,33 @@
+"""
+For parquet version of cosmoDC2 and skysim5000
+
+The reader class CosmoDC2ParquetCatalog is the same as DC2TruthParquetCatalog
+but with some metadata processing.
+"""
+from astropy.cosmology import FlatLambdaCDM
+from .dc2_truth_parquet import DC2TruthParquetCatalog
+
+__all__ = ["CosmoDC2ParquetCatalog"]
+
+
+class CosmoDC2ParquetCatalog(DC2TruthParquetCatalog):
+    def _subclass_init(self, **kwargs):
+        super()._subclass_init(**kwargs)
+
+        self.lightcone = kwargs.get('lightcone', True)
+        self.version = kwargs.get('version', '0.0.0')
+        self.halo_mass_def = kwargs.get('halo_mass_def', 'FoF, b=0.168')
+
+        self.cosmology = None
+        if 'cosmology' in kwargs:
+            cosmology = kwargs['cosmology']
+            cosmo_astropy_allowed = FlatLambdaCDM.__init__.__code__.co_varnames[1:]
+            cosmo_astropy = {k: v for k, v in cosmology.items() if k in cosmo_astropy_allowed}
+            self.cosmology = FlatLambdaCDM(**cosmo_astropy)
+            for k, v in cosmology.items():
+                if k not in cosmo_astropy_allowed:
+                    setattr(self.cosmology, k, v)
+
+        self.sky_area = None
+        if 'sky_area' in kwargs:
+            self.sky_area = float(kwargs["sky_area"])

--- a/GCRCatalogs/dc2_truth_parquet.py
+++ b/GCRCatalogs/dc2_truth_parquet.py
@@ -4,24 +4,21 @@ suitable for other catalogs coming from parquet
 """
 
 import os
-import re
-import warnings
 
 from GCR import BaseGenericCatalog
+
 from .parquet import ParquetFileWrapper
 from .parse_utils import PathInfoParser
-
 from .utils import first
 
 __all__ = ['DC2TruthParquetCatalog']
 
 
-    
 class DC2TruthParquetCatalog(BaseGenericCatalog):
     r"""
        DC2 Truth (parquet) Catalog reader
 
-       Presents tables exactly as they are defined in the files (no aliases, 
+       Presents tables exactly as they are defined in the files (no aliases,
        no derived quantities)
 
        Parameters
@@ -31,23 +28,23 @@ class DC2TruthParquetCatalog(BaseGenericCatalog):
                                files.
                                Default is match anything
 
-       If filename_pattern contains substrings like "{some_ident}"  where 
-       some_ident is a legal identifier, this part of the pattern will be 
-       replaced with a regex expression for a group matching a string of 
+       If filename_pattern contains substrings like "{some_ident}"  where
+       some_ident is a legal identifier, this part of the pattern will be
+       replaced with a regex expression for a group matching a string of
        digits or word characters,
-       e.g.  
+       e.g.
              (?P<some_ident>\d+) or              (?P<some_ident>\w+)
        The first form will be used iff the identifier is one of a well-known set
        with integer values, currently ('tract', 'visit', 'healpix')
 
        Such group names may be used subsequently as native_filter_quantities
-       If filename_pattern already includes standard regex syntax for named 
+       If filename_pattern already includes standard regex syntax for named
        groups, those group names may also be used as native filters
     """
 
     def _subclass_init(self, **kwargs):
         self.base_dir = kwargs['base_dir']
-        self.path_parser = PathInfoParser(kwargs.get('filename_pattern','.*'))
+        self.path_parser = PathInfoParser(kwargs.get('filename_pattern', '.*'))
 
         if not os.path.isdir(self.base_dir):
             raise ValueError('`base_dir` {} is not a valid directory'.format(self.base_dir))
@@ -59,21 +56,21 @@ class DC2TruthParquetCatalog(BaseGenericCatalog):
         self._columns = first(self._datasets).columns
 
         self._quantity_modifiers = {col: None for col in self._columns}
-        
+
         self._native_filter_quantities = set(self.path_parser.group_names)
         self._len = None
-   
+
     def _generate_datasets(self):
         """Return viable data sets from all files in self.base_dir
 
         Returns:
-            A list of  ParquetFileWrapper objects.  If any native filters come 
+            A list of  ParquetFileWrapper objects.  If any native filters come
             from filepath re, dict of their values will be stored in the object
         """
         datasets = list()
         for fname in sorted(os.listdir(self.base_dir)):
             info_dict = self.path_parser.file_info(fname)
-            if info_dict == None:
+            if info_dict is None:
                 continue
             datasets.append(ParquetFileWrapper(os.path.join(self.base_dir,
                                                             fname),
@@ -93,10 +90,10 @@ class DC2TruthParquetCatalog(BaseGenericCatalog):
         return native_quantity_getter.read_columns_row_group(list(native_quantities_needed), as_dict=True)
 
     def __len__(self):
-        if self._len == None:
+        if self._len is None:
             self._len = sum(len(dataset) for dataset in self._datasets)
         return self._len
-    
+
     def _iter_native_dataset(self, native_filters=None):
         for dataset in self._datasets:
             if (native_filters is not None and
@@ -110,5 +107,3 @@ class DC2TruthParquetCatalog(BaseGenericCatalog):
         """Clear all cached file handles"""
         for dataset in self._datasets:
             dataset.close()
-
-                


### PR DESCRIPTION
This PR adds two catalog configs for the parquet versions of cosmoDC2 and SkySim5000:

- `cosmoDC2_v1.1.4_parquet.yaml`
- `skysim5000_v1.1.1_parquet.yaml`

Both configs use the newly added `CosmoDC2ParquetCatalog` reader class in `cosmodc2_parquet.py`.

The `CosmoDC2ParquetCatalog` is a subclass of the existing `DC2TruthParquetCatalog` in `dc2_truth_parquet.py`. The only addition to `CosmoDC2ParquetCatalog` is to process metadata present in the catalog configs.

Some code style adjustments were applied to `dc2_truth_parquet.py`, but the content of the code has not changed.

This PR fixes #546 