### PR TITLE
Add available_healpix_pixels to cosmoDC2 readers

### DIFF
--- a/GCRCatalogs/cosmodc2.py
+++ b/GCRCatalogs/cosmodc2.py
@@ -389,6 +389,12 @@ class CosmoDC2ParentClass(BaseGenericCatalog):
             return default
         return self._quantity_info.get(q_mod or quantity, default)
 
+    @property
+    def available_healpix_pixels(self):
+        if not self.lightcone:
+            raise AttributeError("Non-lightcone catalog has no attribute 'available_healpix_pixels'")
+        return sorted(set(k[1] for k in self._file_list))
+
 
 class CosmoDC2GalaxyCatalog(CosmoDC2ParentClass):
     """

--- a/GCRCatalogs/cosmodc2_parquet.py
+++ b/GCRCatalogs/cosmodc2_parquet.py
@@ -31,3 +31,7 @@ class CosmoDC2ParquetCatalog(DC2TruthParquetCatalog):
         self.sky_area = None
         if 'sky_area' in kwargs:
             self.sky_area = float(kwargs["sky_area"])
+
+    @property
+    def available_healpix_pixels(self):
+        return sorted((d.info["healpix_pixel"] for d in self._datasets))


### PR DESCRIPTION
This PR fixes #553, adding `available_healpix_pixels` property to the two cosmoDC2/SkySim5000 readers (one for hdf5 and one for parquet), so that they have the same public API for accessing available healpix pixels. 

Similar to `available_tracts` of the Object Catalog, `available_healpix_pixels` will return a list of integers that correspond to available healpix pixel IDs.

(cc @joezuntz)