### PR TITLE
automated update of desc-python:bleed on push to master

### DIFF
--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -36,7 +36,7 @@ jobs:
       - run: docker pull $IMAGE
       - name: Run installation script in docker
         run: |
-          docker run --name=$CONTAINER $IMAGE -v $(pwd)/$INSTALL_SCRIPT:/work/$INSTALL_SCRIPT /bin/bash $INSTALL_SCRIPT
+          docker run -v $(pwd)/$INSTALL_SCRIPT:/work/$INSTALL_SCRIPT --name=$CONTAINER $IMAGE /bin/bash $INSTALL_SCRIPT
           docker commit -m="Installed ${{ github.repository }} master" $CONTAINER $IMAGE
       - name: Test the updated image
         run: |

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -10,10 +10,12 @@ jobs:
   docker-build:
     runs-on: ubuntu-18.04
     strategy:
-      env:
-         TARBALL_URL: https://github.com/${{ github.repository }}/archive/master.zip
+    env:
+      TARBALL_URL: https://github.com/${{ github.repository }}/archive/master.zip
+      
       matrix:
-         image_version: [bleed, latest]
+        image_version: [bleed, latest]
+        
     steps:
       - name: docker login
         run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -10,22 +10,32 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     env:
-      INSTALL_SCRIPT: install.sh
+      SCRIPT_DIR: scripts
+      INSTALL_SCRIPT: scripts/install.sh
+      TEST_SCRIPT: scripts/test.sh
     strategy:
       matrix:
         image_version: [bleed, latest]
     steps:
       - name: Prepare an installation script
         run: |
+          mkdir -p $SCRIPT_DIR
           echo '#!/bin/bash' > $INSTALL_SCRIPT
       - name: Add pre-installation steps for bleed/latest
         if: matrix.image_version == 'bleed' || matrix.image_version == 'latest'
         run: |
           echo 'source /usr/local/py3.7/etc/profile.d/conda.sh' >> $INSTALL_SCRIPT
           echo 'conda activate desc' >> $INSTALL_SCRIPT
+      - name: Make a copy of the installation script for test script
+        run: |
+          cp $INSTALL_SCRIPT $TEST_SCRIPT
       - name: Add installation steps
         run: |
           echo 'pip install https://github.com/${{ github.repository }}/archive/master.zip' >> $INSTALL_SCRIPT
+      - name: Add test steps
+        run: |
+          echo 'python -c "import GCRCatalogs; print(GCRCatalogs.__version__)"' >> $TEST_SCRIPT
+          echo 'python -c "import pyccl; print(pyccl.__version__)"' >> $TEST_SCRIPT
       - name: Set up environment variables for bleed/latest
         if: matrix.image_version == 'bleed' || matrix.image_version == 'latest'
         run: |
@@ -36,10 +46,9 @@ jobs:
       - run: docker pull $IMAGE
       - name: Run installation script in docker
         run: |
-          docker run -v $(pwd)/$INSTALL_SCRIPT:/work/$INSTALL_SCRIPT --name=$CONTAINER $IMAGE /bin/bash /work/$INSTALL_SCRIPT
+          docker run -v $(pwd)/$SCRIPT_DIR:/$SCRIPT_DIR --name=$CONTAINER $IMAGE /bin/bash /$INSTALL_SCRIPT
           docker commit -m="Installed ${{ github.repository }} master" $CONTAINER $IMAGE
       - name: Test the updated image
         run: |
-          docker run $IMAGE python -c 'import GCRCatalogs; print(GCRCatalogs.__version__)'
-          docker run $IMAGE python -c 'import pyccl; print(pyccl.__version__)'
+          docker run -v $(pwd)/$SCRIPT_DIR:/$SCRIPT_DIR --name=$CONTAINER $IMAGE /bin/bash /$TEST_SCRIPT
       - run: docker push $IMAGE

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -36,7 +36,7 @@ jobs:
       - run: docker pull $IMAGE
       - name: Run installation script in docker
         run: |
-          docker run -v $(pwd)/$INSTALL_SCRIPT:/work/$INSTALL_SCRIPT --name=$CONTAINER $IMAGE /bin/bash $INSTALL_SCRIPT
+          docker run -v $(pwd)/$INSTALL_SCRIPT:/work/$INSTALL_SCRIPT --name=$CONTAINER $IMAGE /bin/bash /work/$INSTALL_SCRIPT
           docker commit -m="Installed ${{ github.repository }} master" $CONTAINER $IMAGE
       - name: Test the updated image
         run: |

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -1,4 +1,4 @@
-name: DESC Env Docker Build Test
+name: DESC Env Docker Deployment
 
 on:
   push:

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -9,10 +9,11 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
+       desc_image_ver: [bleed, latest]
        include:
-         - docker_name: updateGCRpy
-           docker_image: lsstdesc/desc-python:latest
-           docker_image_updated: lsstdesc/desc-python:test
+         - docker_name: updateGCR-${{ matrix.desc_image_ver }}
+           docker_image: lsstdesc/desc-python:${{ matrix.desc_image_ver }} 
+           docker_image_updated: lsstdesc/desc-python:${{ matrix.desc_image_ver }}
            conda_activate: "conda activate desc;"
            setup_script: /usr/local/py3.7/etc/profile.d/conda.sh
          ## Disable stack build for now

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -8,26 +8,31 @@ on:
 
 jobs:
   docker-build:
-    runs-on: ubuntu-18.04
-    env:
-      TARBALL_URL: https://github.com/${{ github.repository }}/archive/master.zip
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         image_version: [bleed, latest]
     steps:
       - name: docker login
         run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-      - name: set environment variables for bleed/latest
+      - name: Set up environment variables for bleed/latest
         if: matrix.image_version == 'bleed' || matrix.image_version == 'latest'
         run: |
-          echo "DOCKER_NAME=updateGCR-${{ matrix.image_version }}" >> $GITHUB_ENV            
-          echo "IMAGE_NAME=lsstdesc/desc-python:${{ matrix.image_version }}" >> $GITHUB_ENV
-          echo "PRE_INSTALL='source /usr/local/py3.7/etc/profile.d/conda.sh; conda activate desc;'" >> $GITHUB_ENV
-          echo "TEST_INSTALL='source /usr/local/py3.7/etc/profile.d/conda.sh; conda activate desc; python -c 'import GCRCatalogs; import pyccl''" >> $GITHUB_ENV
-      - run: docker pull "$IMAGE_NAME"
+          echo "CONTAINER=updateGCR-${{ matrix.image_version }}" >> $GITHUB_ENV
+          echo "IMAGE=lsstdesc/desc-python:${{ matrix.image_version }}" >> $GITHUB_ENV
+      - run: docker pull $IMAGE
+      - name: Start a docker container
+        run: docker run --name=$CONTAINER $IMAGE bash
+      - name: Set up pre-installation steps for bleed/latest
+        if: matrix.image_version == 'bleed' || matrix.image_version == 'latest'
+        run:
+          docker exec $CONTAINER source /usr/local/py3.7/etc/profile.d/conda.sh
+          docker exec $CONTAINER conda activate desc
       - name: Install master branch of ${{ github.repository }}
-        run: docker run --name=$DOCKER_NAME $IMAGE_NAME /bin/bash -c "$PRE_INSTALL pip install $TARBALL_URL"
-      - run: docker commit -m="Installed ${{ github.repository }} master" $DOCKER_NAME $IMAGE_NAME        
-      - name: Test new $IMAGE_NAME 
-        run: docker run --rm $IMAGE_NAME /bin/bash -c "$TEST_INSTALL"
-      - run: docker push $IMAGE_NAME
+        run: docker exec $CONTAINER pip install https://github.com/${{ github.repository }}/archive/master.zip
+      - run: docker commit -m="Installed ${{ github.repository }} master" $CONTAINER $IMAGE
+      - name: Test new $CONTAINER
+        run: |
+          docker exec $CONTAINER python -c 'import GCRCatalogs; print(GCRCatalogs.__version__)'
+          docker exec $CONTAINER python -c 'import pyccl; print(pyccl.__version__)'
+      - run: docker push $IMAGE

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -14,20 +14,20 @@ jobs:
          TARBALL_URL: https://github.com/${{ github.repository }}/archive/master.zip
       matrix:
          image_version: [bleed, latest]
-      steps:
-        - name: docker login
-          run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-        - name: set environment variables for bleed/latest
-          if: matrix.image_version == 'bleed' || matrix.image_version == 'latest'
-          run: |
-            echo "DOCKER_NAME=updateGCR-${{ matrix.image_version }}" >> $GITHUB_ENV
-            echo "IMAGE_NAME=lsstdesc/desc-python:${{ matrix.image_version }}" >> $GITHUB_ENV
-            echo "PRE_INSTALL='source /usr/local/py3.7/etc/profile.d/conda.sh; conda activate desc;'" >> $GITHUB_ENV
-            echo "TEST_INSTALL='source /usr/local/py3.7/etc/profile.d/conda.sh; conda activate desc; python -c 'import GCRCatalogs; import pyccl''" >> $GITHUB_ENV
-        - run: docker pull "$IMAGE_NAME"
-        - name: Install master branch of ${{ github.repository }}
-          run: docker run --name=$DOCKER_NAME $IMAGE_NAME /bin/bash -c "$PRE_INSTALL pip install $TARBALL_URL"
-        - run: docker commit -m="Installed ${{ github.repository }} master" $DOCKER_NAME $IMAGE_NAME
-        - name: Test new $IMAGE_NAME 
-          run: docker run --rm $IMAGE_NAME /bin/bash -c "$TEST_INSTALL"
-        - run: docker push $IMAGE_NAME
+    steps:
+      - name: docker login
+        run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+      - name: set environment variables for bleed/latest
+        if: matrix.image_version == 'bleed' || matrix.image_version == 'latest'
+        run: |
+          echo "DOCKER_NAME=updateGCR-${{ matrix.image_version }}" >> $GITHUB_ENV            
+          echo "IMAGE_NAME=lsstdesc/desc-python:${{ matrix.image_version }}" >> $GITHUB_ENV
+          echo "PRE_INSTALL='source /usr/local/py3.7/etc/profile.d/conda.sh; conda activate desc;'" >> $GITHUB_ENV
+          echo "TEST_INSTALL='source /usr/local/py3.7/etc/profile.d/conda.sh; conda activate desc; python -c 'import GCRCatalogs; import pyccl''" >> $GITHUB_ENV
+      - run: docker pull "$IMAGE_NAME"
+      - name: Install master branch of ${{ github.repository }}
+        run: docker run --name=$DOCKER_NAME $IMAGE_NAME /bin/bash -c "$PRE_INSTALL pip install $TARBALL_URL"
+      - run: docker commit -m="Installed ${{ github.repository }} master" $DOCKER_NAME $IMAGE_NAME        
+      - name: Test new $IMAGE_NAME 
+        run: docker run --rm $IMAGE_NAME /bin/bash -c "$TEST_INSTALL"
+      - run: docker push $IMAGE_NAME

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -10,26 +10,24 @@ jobs:
   docker-build:
     runs-on: ubuntu-18.04
     strategy:
+      env:
+         TARBALL_URL: https://github.com/${{ github.repository }}/archive/master.zip
       matrix:
-       desc_image_ver: [bleed, latest]
-       include:
-         - docker_name: updateGCR-${{ matrix.desc_image_ver }}
-           docker_image: lsstdesc/desc-python:${{ matrix.desc_image_ver }} 
-           docker_image_updated: lsstdesc/desc-python:${{ matrix.desc_image_ver }}
-           conda_activate: "conda activate desc;"
-           setup_script: /usr/local/py3.7/etc/profile.d/conda.sh
-         ## Disable stack build for now
-         #- docker_name: updateGCRstack
-         #  docker_image: lsstdesc/stack-jupyter:prod
-         #  docker_image_updated: lsstdesc/stack-jupyter:test
-         #  conda_activate: ""
-         #  setup_script: /opt/lsst/software/stack/loadLSST.bash
-
-    steps:
-      - name: docker login
-        run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-      - run: docker pull ${{ matrix.docker_image }}
-      - name: Install master branch of ${{ github.repository }}
-        run: docker run --name=${{ matrix.docker_name }} ${{ matrix.docker_image }} /bin/bash -c "source ${{ matrix.setup_script }}; ${{ matrix.conda_activate }} pip install https://github.com/${{ github.repository }}/archive/master.zip"
-      - run: docker commit -m="Installed ${{ github.repository }} master" ${{ matrix.docker_name }} ${{ matrix.docker_image_updated }}
-      - run: docker push ${{ matrix.docker_image_updated }}
+         image_version: [bleed, latest]
+      steps:
+        - name: docker login
+          run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+        - name: set environment variables for bleed/latest
+          if: matrix.image_version == 'bleed' || matrix.image_version == 'latest'
+          run: |
+            echo "DOCKER_NAME=updateGCR-${{ matrix.image_version }}" >> $GITHUB_ENV
+            echo "IMAGE_NAME=lsstdesc/desc-python:${{ matrix.image_version }}" >> $GITHUB_ENV
+            echo "PRE_INSTALL='source /usr/local/py3.7/etc/profile.d/conda.sh; conda activate desc;'" >> $GITHUB_ENV
+            echo "TEST_INSTALL='source /usr/local/py3.7/etc/profile.d/conda.sh; conda activate desc; python -c 'import GCRCatalogs; import pyccl''" >> $GITHUB_ENV
+        - run: docker pull "$IMAGE_NAME"
+        - name: Install master branch of ${{ github.repository }}
+          run: docker run --name=$DOCKER_NAME $IMAGE_NAME /bin/bash -c "$PRE_INSTALL pip install $TARBALL_URL"
+        - run: docker commit -m="Installed ${{ github.repository }} master" $DOCKER_NAME $IMAGE_NAME
+        - name: Test new $IMAGE_NAME 
+          run: docker run --rm $IMAGE_NAME /bin/bash -c "$TEST_INSTALL"
+        - run: docker push $IMAGE_NAME

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -3,8 +3,6 @@ name: DESC Env Docker Deployment
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   docker-build:

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -9,30 +9,37 @@ on:
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    env:
+      INSTALL_SCRIPT: install.sh
     strategy:
       matrix:
         image_version: [bleed, latest]
     steps:
-      - name: docker login
-        run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+      - name: Prepare an installation script
+        run: |
+          echo '#!/bin/bash' > $INSTALL_SCRIPT
+      - name: Add pre-installation steps for bleed/latest
+        if: matrix.image_version == 'bleed' || matrix.image_version == 'latest'
+        run: |
+          echo 'source /usr/local/py3.7/etc/profile.d/conda.sh' >> $INSTALL_SCRIPT
+          echo 'conda activate desc' >> $INSTALL_SCRIPT
+      - name: Add installation steps
+        run: |
+          echo 'pip install https://github.com/${{ github.repository }}/archive/master.zip' >> $INSTALL_SCRIPT
       - name: Set up environment variables for bleed/latest
         if: matrix.image_version == 'bleed' || matrix.image_version == 'latest'
         run: |
           echo "CONTAINER=updateGCR-${{ matrix.image_version }}" >> $GITHUB_ENV
           echo "IMAGE=lsstdesc/desc-python:${{ matrix.image_version }}" >> $GITHUB_ENV
+      - name: Run docker login
+        run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
       - run: docker pull $IMAGE
-      - name: Start a docker container
-        run: docker run --name=$CONTAINER $IMAGE bash
-      - name: Set up pre-installation steps for bleed/latest
-        if: matrix.image_version == 'bleed' || matrix.image_version == 'latest'
-        run:
-          docker exec $CONTAINER source /usr/local/py3.7/etc/profile.d/conda.sh
-          docker exec $CONTAINER conda activate desc
-      - name: Install master branch of ${{ github.repository }}
-        run: docker exec $CONTAINER pip install https://github.com/${{ github.repository }}/archive/master.zip
-      - run: docker commit -m="Installed ${{ github.repository }} master" $CONTAINER $IMAGE
-      - name: Test new $CONTAINER
+      - name: Run installation script in docker
         run: |
-          docker exec $CONTAINER python -c 'import GCRCatalogs; print(GCRCatalogs.__version__)'
-          docker exec $CONTAINER python -c 'import pyccl; print(pyccl.__version__)'
+          docker run --name=$CONTAINER $IMAGE -v $(pwd)/$INSTALL_SCRIPT:/work/$INSTALL_SCRIPT /bin/bash $INSTALL_SCRIPT
+          docker commit -m="Installed ${{ github.repository }} master" $CONTAINER $IMAGE
+      - name: Test the updated image
+        run: |
+          docker run $IMAGE python -c 'import GCRCatalogs; print(GCRCatalogs.__version__)'
+          docker run $IMAGE python -c 'import pyccl; print(pyccl.__version__)'
       - run: docker push $IMAGE

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -3,6 +3,8 @@ name: DESC Env Docker Build Test
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   docker-build:

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -48,7 +48,8 @@ jobs:
         run: |
           docker run -v $(pwd)/$SCRIPT_DIR:/$SCRIPT_DIR --name=$CONTAINER $IMAGE /bin/bash /$INSTALL_SCRIPT
           docker commit -m="Installed ${{ github.repository }} master" $CONTAINER $IMAGE
+          docker rm $CONTAINER
       - name: Test the updated image
         run: |
-          docker run -v $(pwd)/$SCRIPT_DIR:/$SCRIPT_DIR --name=$CONTAINER $IMAGE /bin/bash /$TEST_SCRIPT
+          docker run --rm -v $(pwd)/$SCRIPT_DIR:/$SCRIPT_DIR $IMAGE /bin/bash /$TEST_SCRIPT
       - run: docker push $IMAGE

--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -9,13 +9,11 @@ on:
 jobs:
   docker-build:
     runs-on: ubuntu-18.04
-    strategy:
     env:
       TARBALL_URL: https://github.com/${{ github.repository }}/archive/master.zip
-      
+    strategy:
       matrix:
         image_version: [bleed, latest]
-        
     steps:
       - name: docker login
         run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin


### PR DESCRIPTION
fix #555
Think this will cause 2 workflows to run for every push to master on gcr-catalogs.  The first will update the desc-python:bleed docker image and the second will update desc-python:latest.  Not sure how to test other than just letting it run!
Might want to think about updating the os to ubuntu-20.04