### PR TITLE
Issues/561/wfdphotozreader

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2_with_addons.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2_with_addons.yaml
@@ -18,6 +18,15 @@ catalogs:
     overwrite_quantities: false
     overwrite_attributes: false
     include_native_quantities: false
+  - subclass_name: dc2_photoz_parquet.DC2PhotozCatalog
+    base_dir: ^/DC2-prod/Run2.2i/addons/photoz/dr6_v2
+    filename_pattern: 'photoz_pdf_Run2.2i_dr6_tract_\d+\.parquet$'
+    as_object_addon: true
+    matching_partition: true
+    matching_row_order: true
+    overwrite_quantities: false
+    overwrite_attributes: false
+    include_native_quantities: false
 
 description: DC2 Run 2.2i DR6 Object Table v2 with all available add-ons (currently only metacal and truth-match)
 creators: ['DESC DC2 Team']

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2_with_addons.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2_with_addons.yaml
@@ -21,7 +21,6 @@ catalogs:
   - subclass_name: dc2_photoz_parquet.DC2PhotozCatalog
     base_dir: ^/DC2-prod/Run2.2i/addons/photoz/dr6_v2
     filename_pattern: 'photoz_pdf_Run2.2i_dr6_tract_\d+\.parquet$'
-    as_object_addon: true
     matching_partition: true
     matching_row_order: true
     overwrite_quantities: false

--- a/GCRCatalogs/catalog_configs/photoz_dc2_object_run2.2i_dr6_v2.yaml
+++ b/GCRCatalogs/catalog_configs/photoz_dc2_object_run2.2i_dr6_v2.yaml
@@ -1,0 +1,6 @@
+subclass_name: dc2_photoz_parquet.DC2PhotozCatalog
+base_dir: ^/DC2-prod/Run2.2i/addons/photoz/dr6_v2 
+filename_pattern: 'photoz_pdf_Run2.2i_dr6_tract_\d+\.parquet$'
+description: DC2 Run 2.2i_dr6_v1 BPZ Photoz table
+creators: ['Sam Schmidt, DESC DC2 team']
+addon_for: dc2_object_run2.2i_dr6_v1

--- a/GCRCatalogs/catalog_configs/photoz_dc2_object_run2.2i_dr6_v2.yaml
+++ b/GCRCatalogs/catalog_configs/photoz_dc2_object_run2.2i_dr6_v2.yaml
@@ -1,6 +1,0 @@
-subclass_name: dc2_photoz_parquet.DC2PhotozCatalog
-base_dir: ^/DC2-prod/Run2.2i/addons/photoz/dr6_v2 
-filename_pattern: 'photoz_pdf_Run2.2i_dr6_tract_\d+\.parquet$'
-description: DC2 Run 2.2i_dr6_v1 BPZ Photoz table
-creators: ['Sam Schmidt, DESC DC2 team']
-addon_for: dc2_object_run2.2i_dr6_v2

--- a/GCRCatalogs/catalog_configs/photoz_dc2_object_run2.2i_dr6_v2.yaml
+++ b/GCRCatalogs/catalog_configs/photoz_dc2_object_run2.2i_dr6_v2.yaml
@@ -3,4 +3,4 @@ base_dir: ^/DC2-prod/Run2.2i/addons/photoz/dr6_v2
 filename_pattern: 'photoz_pdf_Run2.2i_dr6_tract_\d+\.parquet$'
 description: DC2 Run 2.2i_dr6_v1 BPZ Photoz table
 creators: ['Sam Schmidt, DESC DC2 team']
-addon_for: dc2_object_run2.2i_dr6_v1
+addon_for: dc2_object_run2.2i_dr6_v2


### PR DESCRIPTION
This PR addresses issue #561 to add a reader for run2.2i_dr6_v2 photo-z catalog for BPZ.  I did a quick check and things seem to work properly for grabbing both mag_i_cModel and photoz_mode, @yymao you might want to look at the parameters that I set in dc2_object_run2.2i_dr6_v2_with_addons.yaml and make sure that I made the proper choices.  