### PR TITLE
Update desc-env-test GH Action

### DIFF
--- a/.github/workflows/desc-env-test.yml
+++ b/.github/workflows/desc-env-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Add pre-installation steps for bleed/latest
         if: matrix.image_version == 'bleed' || matrix.image_version == 'latest'
         run: |
-          echo 'source /usr/local/py3.7/etc/profile.d/conda.sh' >> $INSTALL_SCRIPT
+          echo 'source /usr/local/py/etc/profile.d/conda.sh' >> $INSTALL_SCRIPT
           echo 'conda activate desc' >> $INSTALL_SCRIPT
       - name: Make a copy of the installation script for test script
         run: |


### PR DESCRIPTION
Fix #574 
The desc-python image now installs the conda environment in `/usr/local/py` and avoids explicitly mentioning the python version.  This will allow easier upgrades in the future.