### PR TITLE
Add "nersc_public" as a site

### DIFF
--- a/GCRCatalogs/site_config/site_rootdir.yaml
+++ b/GCRCatalogs/site_config/site_rootdir.yaml
@@ -1,2 +1,3 @@
 nersc: /global/cfs/cdirs/lsst/shared
 in2p3: /sps/lsst/groups/desc/shared
+nersc_public: /global/cfs/cdirs/lsst/gsharing


### PR DESCRIPTION
This allows users on nersc to run 

```python
GCRCatalogs.set_root_dir_by_site("nersc_public")
```
to switch to the public released root dir. 