### PR TITLE
update dc2_object_run2.2i_dr6_v2_with_addons

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2_with_addons.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2_with_addons.yaml
@@ -1,31 +1,6 @@
-subclass_name: composite.CompositeReader
-catalogs:
-  - catalog_name: dc2_object_run2.2i_dr6_v2
-  - subclass_name: dc2_metacal.DC2MetacalCatalog
-    base_dir: ^/DC2-prod/Run2.2i/dpdd/Run2.2i-dr6-v2/metacal_table_summary
-    bands: griz
-    apply_metacal_test3_fix: true
-    matching_partition: true
-    matching_row_order: true
-    overwrite_quantities: false
-    overwrite_attributes: false
-    include_native_quantities: true
-  - subclass_name: dc2_truth_match.DC2TruthMatchCatalog
-    base_dir: ^/DC2-prod/Run2.2i/truth/tract_partition/match_dr6_v2
-    as_object_addon: true
-    matching_partition: true
-    matching_row_order: true
-    overwrite_quantities: false
-    overwrite_attributes: false
-    include_native_quantities: false
-  - subclass_name: dc2_photoz_parquet.DC2PhotozCatalog
-    base_dir: ^/DC2-prod/Run2.2i/addons/photoz/dr6_v2
-    filename_pattern: 'photoz_pdf_Run2.2i_dr6_tract_\d+\.parquet$'
-    matching_partition: true
-    matching_row_order: true
-    overwrite_quantities: false
-    overwrite_attributes: false
-    include_native_quantities: false
-
-description: DC2 Run 2.2i DR6 Object Table v2 with all available add-ons (currently only metacal and truth-match)
-creators: ['DESC DC2 Team']
+alias: dc2_object_run2.2i_dr6_v2_with_addons_v1
+include_in_default_catalog_list: true
+deprecated: |
+  This catalog is currently pointing to dc2_object_run2.2i_dr6_v2_with_addons_v1, which has been deprecated in May 2022.
+  In the near future this catalog will point to dc2_object_run2.2i_dr6_v2_with_addons_v2, which has an updated truth-match addon.
+  Please start to update your code to use dc2_object_run2.2i_dr6_v2_with_addons_v2 instead.

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2_with_addons_v1.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2_with_addons_v1.yaml
@@ -1,0 +1,32 @@
+subclass_name: composite.CompositeReader
+catalogs:
+  - catalog_name: dc2_object_run2.2i_dr6_v2
+  - subclass_name: dc2_metacal.DC2MetacalCatalog
+    base_dir: ^/DC2-prod/Run2.2i/dpdd/Run2.2i-dr6-v2/metacal_table_summary
+    bands: griz
+    apply_metacal_test3_fix: true
+    matching_partition: true
+    matching_row_order: true
+    overwrite_quantities: false
+    overwrite_attributes: false
+    include_native_quantities: true
+  - subclass_name: dc2_truth_match.DC2TruthMatchCatalog
+    base_dir: ^/DC2-prod/Run2.2i/truth/tract_partition/match_dr6_v2
+    as_object_addon: true
+    matching_partition: true
+    matching_row_order: true
+    overwrite_quantities: false
+    overwrite_attributes: false
+    include_native_quantities: false
+  - subclass_name: dc2_photoz_parquet.DC2PhotozCatalog
+    base_dir: ^/DC2-prod/Run2.2i/addons/photoz/dr6_v2
+    filename_pattern: 'photoz_pdf_Run2.2i_dr6_tract_\d+\.parquet$'
+    matching_partition: true
+    matching_row_order: true
+    overwrite_quantities: false
+    overwrite_attributes: false
+    include_native_quantities: false
+
+description: DC2 Run 2.2i DR6 Object Table v2 with all available add-ons (currently only metacal and truth-match)
+creators: ['DESC DC2 Team']
+deprecated: Use dc2_object_run2.2i_dr6_v2_with_addons_v2 instead!

--- a/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2_with_addons_v2.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_object_run2.2i_dr6_v2_with_addons_v2.yaml
@@ -1,0 +1,34 @@
+subclass_name: composite.CompositeReader
+catalogs:
+  - catalog_name: dc2_object_run2.2i_dr6_v2
+  - subclass_name: dc2_metacal.DC2MetacalCatalog
+    base_dir: ^/DC2-prod/Run2.2i/dpdd/Run2.2i-dr6-v2/metacal_table_summary
+    bands: griz
+    apply_metacal_test3_fix: true
+    matching_partition: true
+    matching_row_order: true
+    overwrite_quantities: false
+    overwrite_attributes: false
+    include_native_quantities: true
+  - subclass_name: dc2_truth_match.DC2TruthMatchCatalog
+    base_dir: ^/DC2-prod/Run2.2i/truth/truth_merged_summary_v1-0-0/match_dr6_v2
+    as_object_addon: true
+    matching_partition: true
+    matching_row_order: true
+    overwrite_quantities: false
+    overwrite_attributes: false
+    include_native_quantities: false
+  - subclass_name: dc2_photoz_parquet.DC2PhotozCatalog
+    base_dir: ^/DC2-prod/Run2.2i/addons/photoz/dr6_v2
+    filename_pattern: 'photoz_pdf_Run2.2i_dr6_tract_\d+\.parquet$'
+    matching_partition: true
+    matching_row_order: true
+    overwrite_quantities: false
+    overwrite_attributes: false
+    include_native_quantities: false
+
+description: |
+  DC2 Run 2.2i DR6 Object Table v2 with all available add-ons (currently only metacal and truth-match).
+  The truth-match addon was updated in May 2022.
+creators: ['DESC DC2 Team']
+include_in_default_catalog_list: true


### PR DESCRIPTION
In this PR:

- The original `dc2_object_run2.2i_dr6_v2_with_addons` was renamed to `dc2_object_run2.2i_dr6_v2_with_addons_v1`
- `dc2_object_run2.2i_dr6_v2_with_addons_v2` was created with the new truth match addon
- `dc2_object_run2.2i_dr6_v2_with_addons` was changed to an alias config, currently still pointing to `dc2_object_run2.2i_dr6_v2_with_addons_v1` so that it doesn't break anyone's one. A deprecation message was added to encourage users to update to `dc2_object_run2.2i_dr6_v2_with_addons_v2`. 

Thanks @johannct for suggestion. 