### PR TITLE
Nersc ci

### DIFF
--- a/.github/workflows/nersc_ci.yml
+++ b/.github/workflows/nersc_ci.yml
@@ -4,21 +4,21 @@ on: [workflow_dispatch]
 
 env:
   # URL to source repository on GitHub.
-  GITHUB_SOURCE_REPO: https://github.com/LSSTDESC/<source-repo>.git
+  GITHUB_SOURCE_REPO: https://github.com/LSSTDESC/gcr-catalogs.git
   # Branch to work with.
-  GITHUB_SOURCE_BRANCH: main
+  GITHUB_SOURCE_BRANCH: nersc_ci
   
   # URL to target repository on GitLab and its project number.
-  GITLAB_TARGET_REPO: https://software.nersc.gov/<namespace>/<target-repo>.git
-  GITLAB_TARGET_PROJECT_NUMBER: <target-repo-project-number>
+  GITLAB_TARGET_REPO: https://software.nersc.gov/mcalpine/gcr-catalogs.git
+  GITLAB_TARGET_PROJECT_NUMBER: 453
   
   # URL to mirror repository on GitLab and its project number.
-  GITLAB_MIRROR_REPO: https://software.nersc.gov/<namespace>/<mirror-repo>.git
-  GITLAB_MIRROR_PROJECT_NUMBER: <mirror-repo-project-number>
+  GITLAB_MIRROR_REPO: https://software.nersc.gov/<namespace>/mirror-gcr-catalogs.git
+  GITLAB_MIRROR_PROJECT_NUMBER: 454
   
   # URL to status repository on GitLab, its project number, and tag.
-  GITLAB_STATUS_REPO: https://software.nersc.gov/<namespace>/<status-repo>.git
-  GITLAB_STATUS_PROJECT_NUMBER: <status-repo-project-number>
+  GITLAB_STATUS_REPO: https://software.nersc.gov/<namespace>/status-gcr-catalogs.git
+  GITLAB_STATUS_PROJECT_NUMBER: 455
   GITLAB_STATUS_CONTEXT: NERSC
   
 jobs:

--- a/.github/workflows/nersc_ci.yml
+++ b/.github/workflows/nersc_ci.yml
@@ -1,0 +1,45 @@
+name: Trigger NERSC CI
+
+on: [workflow_dispatch]
+
+env:
+  # URL to source repository on GitHub.
+  GITHUB_SOURCE_REPO: https://github.com/LSSTDESC/<source-repo>.git
+  # Branch to work with.
+  GITHUB_SOURCE_BRANCH: main
+  
+  # URL to target repository on GitLab and its project number.
+  GITLAB_TARGET_REPO: https://software.nersc.gov/<namespace>/<target-repo>.git
+  GITLAB_TARGET_PROJECT_NUMBER: <target-repo-project-number>
+  
+  # URL to mirror repository on GitLab and its project number.
+  GITLAB_MIRROR_REPO: https://software.nersc.gov/<namespace>/<mirror-repo>.git
+  GITLAB_MIRROR_PROJECT_NUMBER: <mirror-repo-project-number>
+  
+  # URL to status repository on GitLab, its project number, and tag.
+  GITLAB_STATUS_REPO: https://software.nersc.gov/<namespace>/<status-repo>.git
+  GITLAB_STATUS_PROJECT_NUMBER: <status-repo-project-number>
+  GITLAB_STATUS_CONTEXT: NERSC
+  
+jobs:
+  trigger-mirror-repo-ci:
+  
+    runs-on: ubuntu-latest
+    
+    steps:
+      # Trigger mirror repository CI workflow, passing variables as we go.
+      - run: >-
+           curl -X POST --fail 
+           --form "variables[GITLAB_STATUS_REPO]=$GITLAB_STATUS_REPO"
+           --form "variables[GITLAB_TARGET_REPO]=$GITLAB_TARGET_REPO"
+           --form "variables[GITLAB_MIRROR_REPO]=$GITLAB_MIRROR_REPO"
+           --form "variables[GITHUB_SOURCE_REPO]=$GITHUB_SOURCE_REPO"
+           --form "variables[GITHUB_SOURCE_BRANCH]=$GITHUB_SOURCE_BRANCH"
+           --form "variables[GITLAB_TARGET_PROJECT_NUMBER]=$GITLAB_TARGET_PROJECT_NUMBER"
+           --form "variables[GITLAB_MIRROR_PROJECT_NUMBER]=$GITLAB_MIRROR_PROJECT_NUMBER"
+           --form "variables[GITLAB_STATUS_PROJECT_NUMBER]=$GITLAB_STATUS_PROJECT_NUMBER"
+           --form "variables[GITLAB_STATUS_CONTEXT]=$GITLAB_STATUS_CONTEXT"
+           --form "variables[GITHUB_SHA]=${{ github.sha }}"
+           --form token=${{ secrets.MIRROR_TRIGGER_TOKEN }}
+           --form ref=main
+           https://software.nersc.gov/api/v4/projects/$GITLAB_MIRROR_PROJECT_NUMBER/trigger/pipeline

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,41 @@
+variables:
+  # Cori queue submission options.
+  SCHEDULER_PARAMETERS: "-C haswell -M escori -q xfer -N1 -t 01:00:00"
+
+# How is this workflow triggered?
+workflow:
+  rules:
+    # Can only be initiated via a trigger token.
+    - if: $CI_PIPELINE_SOURCE == "trigger"
+      when: always
+
+# The CI job.
+example:
+
+  # Running on Cori.
+  tags: [cori]
+
+  script:
+    - module load python3/3.9-anaconda-2021.11
+    - python -m pip install --upgrade pip
+    - pip install wheel
+    - pip install .[full]
+    - pip install pytest
+    - pytest --no-catalog --cori-ci
+
+    # Trigger the status repository CI workflow to report results.
+    - >
+      curl -X POST --fail
+      --form "variables[GITLAB_STATUS_REPO]=$GITLAB_STATUS_REPO"
+      --form "variables[GITLAB_TARGET_REPO]=$GITLAB_TARGET_REPO"
+      --form "variables[GITLAB_MIRROR_REPO]=$GITLAB_MIRROR_REPO"
+      --form "variables[GITHUB_SOURCE_REPO]=$GITHUB_SOURCE_REPO"
+      --form "variables[GITHUB_SOURCE_BRANCH]=$GITHUB_SOURCE_BRANCH"
+      --form "variables[GITLAB_TARGET_PROJECT_NUMBER]=$GITLAB_TARGET_PROJECT_NUMBER"
+      --form "variables[GITLAB_MIRROR_PROJECT_NUMBER]=$GITLAB_MIRROR_PROJECT_NUMBER"
+      --form "variables[GITLAB_STATUS_PROJECT_NUMBER]=$GITLAB_STATUS_PROJECT_NUMBER"
+      --form "variables[GITLAB_STATUS_CONTEXT]=$GITLAB_STATUS_CONTEXT"
+      --form "variables[GITHUB_SHA]=$GITHUB_SHA"
+      --form token=$STATUS_TRIGGER_TOKEN
+      --form ref=main
+      https://software.nersc.gov/api/v4/projects/$GITLAB_STATUS_PROJECT_NUMBER/trigger/pipeline

--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,9 @@ def pytest_addoption(parser):
     parser.addoption(
         "--no-catalog", action="store_true", default=False, help="skip tests that need catalogs"
     )
+    parser.addoption(
+        "--cori-ci", action="store_true", default=False, help="flag to run test_catalogs_ci.py"
+    )
 
 _SKIP_IF_NO_CATALOG = {
     'test_protoDC2.py',
@@ -14,4 +17,7 @@ _SKIP_IF_NO_CATALOG = {
 
 def pytest_ignore_collect(path, config):
     if config.getoption('--no-catalog') and path.basename in _SKIP_IF_NO_CATALOG:
+        return True
+
+    if not config.getoption('--cori-ci') and path.basename == "test_catalogs_ci.py":
         return True

--- a/tests/test_catalogs_ci.py
+++ b/tests/test_catalogs_ci.py
@@ -1,0 +1,17 @@
+"""
+test_catalogs_ci.py
+"""
+import GCRCatalogs
+
+TEST_CATALOG = 'cosmoDC2_v1.1.4_small'
+
+def test_load_catalog_and_quantities_for_ci():
+
+    all_catalogs = list(GCRCatalogs.get_available_catalogs(include_default_only=False))
+    assert TEST_CATALOG in all_catalogs, 'Test catalog missing'
+
+    cat = GCRCatalogs.load_catalog(TEST_CATALOG)
+    qs = cat.list_all_quantities()[:1] + cat.list_all_native_quantities()[:1]
+    assert qs, 'No quantities found in ' + TEST_CATALOG
+    data = next(cat.get_quantities(qs, return_iterator=True))
+    assert all(data.get(q) is not None for q in qs), 'some quantities cannot be loaded'


### PR DESCRIPTION
**Added a github actions workflow (nersc-ci.yml):**

This triggers the NERSC CI pipeline. At the moment this is just triggered manually, however you can change this to on push, schedule, etc.

**Added quick catalog test for ci (./tests/test_catalogs_ci-py):**

This gets run with the --cori-ci flag for pytest. It just reads a few value from the cosmoDC2_v1.1.4_small, however you can change this to what you need.
 
**Added a gitlab workflow (.gitlab-ci.yml):**

This is what gets run on Cori, at the moment it just installs gcr-catalogs and runs pytest on the new test file

I don't have permission to run workflows on this repo (I think). The repos the nersc-ci.yml file points to are my NERSC GitLab repos. You'll have to make repos in your NERSC instance and change the values in the nersc-ci.yml file.  Setup for repos is in the docs for CI repo (https://desc-continuous-integration.readthedocs.io/en/latest/desc/ci_at_nersc.html)
