### PR TITLE
Point desc_dc2_run2.2i_dr6_v4_object to v4 directory

### DIFF
--- a/GCRCatalogs/catalog_configs/desc_dc2_run2.2i_dr6_v4_object.yaml
+++ b/GCRCatalogs/catalog_configs/desc_dc2_run2.2i_dr6_v4_object.yaml
@@ -1,8 +1,3 @@
-subclass_name: dc2_object.DC2ObjectParquetCatalog
+based_on: desc_dc2_run2.2i_dr6_v2_object
 base_dir: ^/lsstdesc-public/dc2/run2.2i-dr6-v4/object_dpdd
-filename_pattern: object_dpdd_tract\d+.parquet$
-is_dpdd: true
-
-description: DESC DC2 (Run2.2i) DR6 Object Table for the Public Release v4 (identical to v2)
-creators: Rubin LSST DESC DC2 Team
 public_release: [v4]

--- a/GCRCatalogs/catalog_configs/desc_dc2_run2.2i_dr6_v4_object.yaml
+++ b/GCRCatalogs/catalog_configs/desc_dc2_run2.2i_dr6_v4_object.yaml
@@ -1,2 +1,8 @@
-alias: desc_dc2_run2.2i_dr6_v2_object
+subclass_name: dc2_object.DC2ObjectParquetCatalog
+base_dir: ^/lsstdesc-public/dc2/run2.2i-dr6-v4/object_dpdd
+filename_pattern: object_dpdd_tract\d+.parquet$
+is_dpdd: true
+
+description: DESC DC2 (Run2.2i) DR6 Object Table for the Public Release v4 (identical to v2)
+creators: Rubin LSST DESC DC2 Team
 public_release: [v4]


### PR DESCRIPTION
As reported #604, `desc_dc2_run2.2i_dr6_v4_object` was an alias of `desc_dc2_run2.2i_dr6_v2_object`. Indeed these two catalogs are identical; however, for public users, if they downloaded the v4 object catalogs, the newly downloaded files will be stored in a directory with `v4` in its path, not `v2`. As a result, `desc_dc2_run2.2i_dr6_v4_object` cannot be set as an alias. 