### PR TITLE
Changes for switching to treecorr convention for position_angle

### DIFF
--- a/GCRCatalogs/SCHEMA.md
+++ b/GCRCatalogs/SCHEMA.md
@@ -55,19 +55,27 @@ Quantity Label | Unit | Definition
 `size_bulge_true` | arcsec | Bulge half-light radius (of major axis), not lensed
 `size_minor_bulge_true` | arcsec | Bulge half-light radius (of minor axis), not lensed
 `position_angle` | deg | Position angle (arctan(E2/E1)), for galaxy, lensed
-`position_angle_true` | deg | Position angle (arctan(E2/E1)), for galaxy, not lensed
+`position_angle_true` | deg | Position angle (arctan(E2/E1)), for galaxy, not lensed, treecorr/GalSim convention
+`position_angle_true_phosim` | deg | Position angle (arctan(E2/E1)), for galaxy, not lensed, phosim convention
+`position_angle_true_dc2` | deg | Position angle (arctan(E2_dc2/E1_dc2)), for galaxy, not lensed; legacy value for DC2
 `ellipticity` | - | Ellipticity (= sqrt(E1^2+E2^2) = (1-q)/(1+q)), for galaxy, lensed, where `q = size_minor/size`
 `ellipticity_1` | - | Ellipticity component 1, for galaxy, lensed
 `ellipticity_2` | - | Ellipticity component 2, for galaxy, lensed
 `ellipticity_true` | - | Ellipticity (= sqrt(E1^2+E2^2) = (1-q)/(1+q)), for galaxy, not lensed, where `q = size_minor_true/size_true`
-`ellipticity_1_true` | - | Ellipticity component 1, for galaxy, not lensed
-`ellipticity_2_true` | - | Ellipticity component 2, for galaxy, not lensed
+`ellipticity_1_true` | - | Ellipticity component 1, for galaxy, not lensed (treecorr/GalSim convention)
+`ellipticity_2_true` | - | Ellipticity component 2, for galaxy, not lensed (treecorr/GalSim convention)
+`ellipticity_1_true_dc2` | - | Ellipticity component 1, for galaxy, not lensed; legacy value for DC2
+`ellipticity_2_true_dc2` | - | Ellipticity component 2, for galaxy, not lensed; legacy value for DC2
 `ellipticity_disk_true` | - | Ellipticity (= sqrt(E1^2+E2^2) = (1-q)/(1+q)), for disk, not lensed, where `q = size_minor_disk_true/size_disk_true`
-`ellipticity_1_disk_true` | - | Ellipticity component 1, for disk, not lensed
-`ellipticity_2_disk_true` | - | Ellipticity component 2, for disk, not lensed
+`ellipticity_1_disk_true` | - | Ellipticity component 1, for disk, not lensed (treecorr/GalSim convention)
+`ellipticity_2_disk_true` | - | Ellipticity component 2, for disk, not lensed (treecorr/GalSim convention)
+`ellipticity_1_disk_true_dc2` | - | Ellipticity component 1, for disk, not lensed; legacy value for DC2
+`ellipticity_2_disk_true_dc2` | - | Ellipticity component 2, for disk, not lensed; legacy value for DC2
 `ellipticity_bulge_true` | - | Ellipticity (= sqrt(E1^2+E2^2) = (1-q)/(1+q)), for bulge, not lensed, where `q = size_minor_bulge_true/size_bulge_true`
-`ellipticity_1_bulge_true` | - | Ellipticity component 1, for bulge, not lensed
-`ellipticity_2_bulge_true` | - | Ellipticity component 2, for bulge, not lensed
+`ellipticity_1_bulge_true` | - | Ellipticity component 1, for bulge, not lensed (treecorr/GalSim convention)
+`ellipticity_2_bulge_true` | - | Ellipticity component 2, for bulge, not lensed (treecorr/GalSim convention)
+`ellipticity_1_bulge_true_dc2` | - | Ellipticity component 1, for bulge, not lensed; legacy value for DC2
+`ellipticity_2_bulge_true_dc2` | - | Ellipticity component 2, for bulge, not lensed; legacy value for DC2
 `shear_1` | - | Shear (gamma) component 1 in treecorr/GalSim convention
 `shear_2` | - | Shear (gamma) component 2 in treecorr/GalSim convention
 `shear_2_treecorr` | - | Shear (gamma) component 2 in treecorr/GalSim convention (`= shear_2`)

--- a/GCRCatalogs/cosmodc2.py
+++ b/GCRCatalogs/cosmodc2.py
@@ -63,8 +63,7 @@ def _gen_position_angle(size_reference):
         _gen_position_angle._pos_angle = np.random.RandomState(123497).uniform(0, 180, size)
     return _gen_position_angle._pos_angle
 
-
-def _calc_ellipticity_1(ellipticity):
+def _calc_ellipticity_1_dc2(ellipticity):
     # position angle using ellipticity as reference for the size or
     # the array. The angle is converted from degrees to radians
     pos_angle = _gen_position_angle(ellipticity)*np.pi/180.0
@@ -73,13 +72,26 @@ def _calc_ellipticity_1(ellipticity):
     return ellipticity*np.cos(2.0*pos_angle)
 
 
-def _calc_ellipticity_2(ellipticity):
+def _calc_ellipticity_2_dc2(ellipticity):
     # position angle using ellipticity as reference for the size or
     # the array. The angle is converted from degrees to radians
     pos_angle = _gen_position_angle(ellipticity)*np.pi/180.0
     # use the correct conversion for ellipticity 2 from ellipticity
     # and position angle
     return ellipticity*np.sin(2.0*pos_angle)
+
+
+def _calc_ellipticity_1(ellipticity, pos_angle):
+    # convert to treecorr convention and from deg to radians
+    pos_angle = np.negative(pos_angle)*np.pi/180.0
+    return ellipticity*np.cos(2.0*pos_angle)
+
+
+def _calc_ellipticity_2(ellipticity, pos_angle):
+    # convert to treecorr convention and from deg to radians
+    pos_angle = np.negative(pos_angle)*np.pi/180.0
+    return ellipticity*np.sin(2.0*pos_angle)
+
 
 def _limit_magnification(mag):
     mag = np.where(mag < 0.2, 1.0, mag)
@@ -426,18 +438,26 @@ class CosmoDC2GalaxyCatalog(CosmoDC2ParentClass):
             'size_bulge_true':          'morphology/spheroidMajorAxisArcsec',
             'size_minor_disk_true':     'morphology/diskMinorAxisArcsec',
             'size_minor_bulge_true':    'morphology/spheroidMinorAxisArcsec',
-            'position_angle_true':      (_gen_position_angle, 'morphology/positionAngle'),
+            'position_angle_true_dc2':  (_gen_position_angle, 'morphology/positionAngle'),
+            'position_angle_true_phosim': 'morphology/positionAngle',
+            'position_angle_true':      (np.negative, 'morphology/positionAngle'),
             'sersic_disk':              'morphology/diskSersicIndex',
             'sersic_bulge':             'morphology/spheroidSersicIndex',
             'ellipticity_true':         'morphology/totalEllipticity',
-            'ellipticity_1_true':       (_calc_ellipticity_1, 'morphology/totalEllipticity'),
-            'ellipticity_2_true':       (_calc_ellipticity_2, 'morphology/totalEllipticity'),
-            'ellipticity_disk_true':    'morphology/diskEllipticity',
-            'ellipticity_1_disk_true':  (_calc_ellipticity_1, 'morphology/diskEllipticity'),
-            'ellipticity_2_disk_true':  (_calc_ellipticity_2, 'morphology/diskEllipticity'),
-            'ellipticity_bulge_true':   'morphology/spheroidEllipticity',
-            'ellipticity_1_bulge_true': (_calc_ellipticity_1, 'morphology/spheroidEllipticity'),
-            'ellipticity_2_bulge_true': (_calc_ellipticity_2, 'morphology/spheroidEllipticity'),
+            'ellipticity_disk_true':         'morphology/diskEllipticity',
+            'ellipticity_bulge_true':        'morphology/spheroidEllipticity',
+            'ellipticity_1_true_dc2':       (_calc_ellipticity_1_dc2, 'morphology/totalEllipticity'),
+            'ellipticity_2_true_dc2':       (_calc_ellipticity_2_dc2, 'morphology/totalEllipticity'),
+            'ellipticity_1_disk_true_dc2':  (_calc_ellipticity_1_dc2, 'morphology/diskEllipticity'),
+            'ellipticity_2_disk_true_dc2':  (_calc_ellipticity_2_dc2, 'morphology/diskEllipticity'),
+            'ellipticity_1_bulge_true_dc2': (_calc_ellipticity_1_dc2, 'morphology/spheroidEllipticity'),
+            'ellipticity_2_bulge_true_dc2': (_calc_ellipticity_2_dc2, 'morphology/spheroidEllipticity'),
+            'ellipticity_1_true':       (_calc_ellipticity_1, 'morphology/totalEllipticity', 'morphology/positionAngle'),
+            'ellipticity_2_true':       (_calc_ellipticity_2, 'morphology/totalEllipticity', 'morphology/positionAngle'),
+            'ellipticity_1_disk_true':  (_calc_ellipticity_1, 'morphology/diskEllipticity', 'morphology/positionAngle'),
+            'ellipticity_2_disk_true':  (_calc_ellipticity_2, 'morphology/diskEllipticity', 'morphology/positionAngle'),
+            'ellipticity_1_bulge_true': (_calc_ellipticity_1, 'morphology/spheroidEllipticity', 'morphology/positionAngle'),
+            'ellipticity_2_bulge_true': (_calc_ellipticity_2, 'morphology/spheroidEllipticity', 'morphology/positionAngle'),
             'size_true': (
                 _calc_weighted_size,
                 'morphology/diskMajorAxisArcsec',


### PR DESCRIPTION
Legacy quantities have been renamed with _dc2. position_angle_true now uses morphology/position_angle and flips the sign to be consistent with the treecorr convention.
ellipticity_1* and ellipticity_2* now use the supplied values of morphology/position_angle and convert to the treecorrr convention before computing the components. 
