### PR TITLE
Use builtin types in place of numpy aliases

### DIFF
--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -171,7 +171,7 @@ class AlphaQGalaxyCatalog(BaseGenericCatalog):
             'magnification': (lambda mag: np.where(mag < 0.2, 1.0, mag), 'magnification'),
             'halo_id':       'hostHaloTag',
             'halo_mass':     (lambda x: x/self.cosmology.h, 'hostHaloMass'),
-            'is_central':    (lambda x: x.astype(np.bool), 'isCentral'),
+            'is_central':    (lambda x: x.astype(bool), 'isCentral'),
             'stellar_mass':  'totalMassStellar',
             'stellar_mass_disk':        'diskMassStellar',
             'stellar_mass_bulge':       'spheroidMassStellar',

--- a/GCRCatalogs/buzzard.py
+++ b/GCRCatalogs/buzzard.py
@@ -86,7 +86,7 @@ class BuzzardGalaxyCatalog(BaseGenericCatalog):
                                    'truth/Z', 'truth/PX', 'truth/PY', 'truth/PZ', 'truth/VX', 'truth/VY', 'truth/VZ'),
                 'halo_id': 'truth/HALOID',
                 'halo_mass': (lambda x: x/self.cosmology.h, 'truth/M200'),
-                'is_central': (lambda x: x.astype(np.bool), 'truth/CENTRAL'),
+                'is_central': (lambda x: x.astype(bool), 'truth/CENTRAL'),
                 'ellipticity_1_true': 'truth/TE/0',
                 'ellipticity_2_true': 'truth/TE/1',
                 'ellipticity_true': (np.hypot, 'truth/TE/0', 'truth/TE/1'),
@@ -147,7 +147,7 @@ class BuzzardGalaxyCatalog(BaseGenericCatalog):
                 'dec_true': 'truth/TDEC',
                 'halo_id': 'truth/HALOID',
                 'halo_mass': (lambda x: x/self.cosmology.h, 'truth/M200'),
-                'is_central': (lambda x: x.astype(np.bool), 'truth/CENTRAL'),
+                'is_central': (lambda x: x.astype(bool), 'truth/CENTRAL'),
                 'ellipticity_1': 'truth/EPSILON/0',
                 'ellipticity_2': 'truth/EPSILON/1',
                 'ellipticity': (np.hypot, 'truth/EPSILON/0', 'truth/EPSILON/1'),
@@ -250,7 +250,7 @@ class BuzzardGalaxyCatalog(BaseGenericCatalog):
 
     def _native_quantity_getter(self, native_quantity, healpix):
         if native_quantity == 'healpix_pixel':
-            data = np.empty(self._open_dataset(healpix, self._default_subset).data.shape, np.int)
+            data = np.empty(self._open_dataset(healpix, self._default_subset).data.shape, int)
             data.fill(healpix)
             return data
 

--- a/GCRCatalogs/cosmodc2.py
+++ b/GCRCatalogs/cosmodc2.py
@@ -430,7 +430,7 @@ class CosmoDC2GalaxyCatalog(CosmoDC2ParentClass):
             'magnification': (lambda mag: np.where(mag < 0.2, 1.0, mag), 'magnification'),
             'halo_id':       'uniqueHaloID',
             'halo_mass':     (lambda x: x/self.cosmology.h, 'hostHaloMass'),
-            'is_central':    (lambda x: x.astype(np.bool), 'isCentral'),
+            'is_central':    (lambda x: x.astype(bool), 'isCentral'),
             'stellar_mass':  'totalMassStellar',
             'stellar_mass_disk':        'diskMassStellar',
             'stellar_mass_bulge':       'spheroidMassStellar',

--- a/GCRCatalogs/dc2_dm_catalog.py
+++ b/GCRCatalogs/dc2_dm_catalog.py
@@ -82,7 +82,7 @@ def create_basic_flag_mask(*flags):
         The combined mask array
     """
 
-    out = np.ones(len(flags[0]), np.bool)
+    out = np.ones(len(flags[0]), bool)
     for flag in flags:
         out &= (~flag)
 

--- a/GCRCatalogs/dc2_object.py
+++ b/GCRCatalogs/dc2_object.py
@@ -70,7 +70,7 @@ def create_basic_flag_mask(*flags):
         The combined mask array
     """
 
-    out = np.ones(len(flags[0]), np.bool)
+    out = np.ones(len(flags[0]), bool)
     for flag in flags:
         out &= (~flag)
 

--- a/GCRCatalogs/dc2_truth.py
+++ b/GCRCatalogs/dc2_truth.py
@@ -138,9 +138,9 @@ class DC2TruthCatalogReader(BaseGenericCatalog):
                 'mag_true_i': 'i',
                 'mag_true_z': 'z',
                 'mag_true_y': 'y',
-                'agn': (lambda x: x.astype(np.bool)),
-                'star': (lambda x: x.astype(np.bool)),
-                'sprinkled': (lambda x: x.astype(np.bool)),
+                'agn': (lambda x: x.astype(bool)),
+                'star': (lambda x: x.astype(bool)),
+                'sprinkled': (lambda x: x.astype(bool)),
             }
 
     def _generate_native_quantity_list(self):

--- a/GCRCatalogs/helpers/base_filters.py
+++ b/GCRCatalogs/helpers/base_filters.py
@@ -31,7 +31,7 @@ def partition_filter(partition_name, ids, id_high=None):
             return GCRQuery(f"{partition_name} >= {ids}", f"{partition_name} <= {id_high}")
         raise ValueError(f"When `{partition_name}s` is an integer, `{partition_name}_high` must be an integer or None.")
 
-    ids = np.unique(np.asarray(ids, dtype=np.int))
+    ids = np.unique(np.asarray(ids, dtype=int))
     if not ids.size:
         raise ValueError(f"Must select at least one {partition_name}.")
 
@@ -58,7 +58,7 @@ def sample_filter(ref_col_name, frac, random_state=None):
     if frac == 1:
         return GCRQuery()
     if frac == 0:
-        return GCRQuery((lambda a: np.zeros_like(a, dtype=np.bool), ref_col_name))
+        return GCRQuery((lambda a: np.zeros_like(a, dtype=bool), ref_col_name))
 
     if not isinstance(random_state, np.random.RandomState):
         random_state = np.random.RandomState(random_state)
@@ -68,6 +68,6 @@ def sample_filter(ref_col_name, frac, random_state=None):
         size = len(arr)  # arr is a numpy array of integers
         if size:
             return np.random.RandomState((int(arr[0]) + seed) % (2**32)).rand(size) < frac
-        return np.zeros(0, dtype=np.bool)
+        return np.zeros(0, dtype=bool)
 
     return GCRQuery((_sampler, ref_col_name))

--- a/GCRCatalogs/reference_catalog.py
+++ b/GCRCatalogs/reference_catalog.py
@@ -41,8 +41,8 @@ class ReferenceCatalogReader(BaseGenericCatalog):
             'dec_unsmeared' : 'decJ2000',
             'sigma_ra' : 'sigma_raJ2000',
             'sigma_dec' : 'sigma_decJ2000',
-            'is_agn': (lambda x: x.astype(np.bool), 'isagn'),
-            'is_resolved': (lambda x: x.astype(np.bool), 'isresolved'),
+            'is_agn': (lambda x: x.astype(bool), 'isagn'),
+            'is_resolved': (lambda x: x.astype(bool), 'isresolved'),
         }
 
         for band in 'ugrizy':
@@ -83,5 +83,5 @@ class ReferenceCatalogReader(BaseGenericCatalog):
             raise ValueError('Cannot find header line!')
 
         fields = [field.strip() for field in line[1:].split(',')]
-        self._data_dtype = np.dtype([(field, np.int if field.startswith('is') or field.endswith('Id') else np.float) for field in fields])
+        self._data_dtype = np.dtype([(field, int if field.startswith('is') or field.endswith('Id') else float) for field in fields])
         return fields


### PR DESCRIPTION
This PR fixes #612.  

This PR replaces numpy builtin type aliases (e.g. `np.bool`) with builtin types (e.g. `bool`), because the former has been deprecated since numpy 1.20.  See "[Using the aliases of builtin types like np.int is deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated)" for detail. 