### PR TITLE
Config files for new catalogs

### DIFF
--- a/GCRCatalogs/catalog_configs/roman_rubin_2023_v1.1.1_elais.yaml
+++ b/GCRCatalogs/catalog_configs/roman_rubin_2023_v1.1.1_elais.yaml
@@ -30,3 +30,5 @@ description: |
     This is the 110 sq. deg. extra-galactic catalog covering the ELAIS field for the Roman-Rubin image simulations for LSST DESC that has been created with fully forward modeled SEDs  
 
 include_in_default_catalog_list: true
+
+deprecated: Use roman_rubin_2023_v1.1.3_elais instead.

--- a/GCRCatalogs/catalog_configs/roman_rubin_2023_v1.1.2_elais.yaml
+++ b/GCRCatalogs/catalog_configs/roman_rubin_2023_v1.1.2_elais.yaml
@@ -1,0 +1,32 @@
+#  Use ^/ to indicate file path relative to GCR root dir
+
+subclass_name: cosmodc2.DiffSkyGalaxyCatalog
+
+catalog_root_dir:   ^/xgal/roman-rubin/roman_rubin_2023_v1.1.2
+catalog_filename_template: roman_rubin_2023_z_{}_{}_cutout_{}.hdf5
+
+healpix_pixels: [9921, 9922, 9923, 9924, 9925, 10050, 10051, 10052, 10053, 10177, 10178, 10179, 10180, 10181, 10305, 10306, 10307, 10308, 10429, 10430, 10431, 10432, 10549, 10550, 10551, 10552, 10665, 10666, 10667, 10668, 10777, 10778, 10779]
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+lightcone: true
+
+version: "1.1.2"
+
+check_md5: false
+check_size: false
+check_cosmology: false
+ensure_meta_consistent: false
+sky_area: 110.7868
+
+creators: ['Andrew Hearin', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Katrin Heitmann']
+
+description: |
+    This is the 110 sq. deg. extra-galactic catalog covering the ELAIS field for the Roman-Rubin image simulations for LSST DESC that has been created with fully forward modeled SEDs  
+
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/roman_rubin_2023_v1.1.3_elais.yaml
+++ b/GCRCatalogs/catalog_configs/roman_rubin_2023_v1.1.3_elais.yaml
@@ -1,0 +1,32 @@
+#  Use ^/ to indicate file path relative to GCR root dir
+
+subclass_name: cosmodc2.DiffSkyGalaxyCatalog
+
+catalog_root_dir:   ^/xgal/roman-rubin/roman_rubin_2023_v1.1.3
+catalog_filename_template: roman_rubin_2023_z_{}_{}_cutout_{}.hdf5
+
+healpix_pixels: [9921, 9922, 9923, 9924, 9925, 10050, 10051, 10052, 10053, 10177, 10178, 10179, 10180, 10181, 10305, 10306, 10307, 10308, 10429, 10430, 10431, 10432, 10549, 10550, 10551, 10552, 10665, 10666, 10667, 10668, 10777, 10778, 10779]
+
+cosmology:
+    H0: 71.0
+    Om0: 0.2648
+    Ob0: 0.0448
+    sigma8: 0.8
+    n_s: 0.963
+
+lightcone: true
+
+version: "1.1.3"
+
+check_md5: false
+check_size: false
+check_cosmology: false
+ensure_meta_consistent: false
+sky_area: 110.7868
+
+creators: ['Andrew Hearin', 'Eve Kovacs', 'Esteban Rangel', 'Patricia Larsen', 'Katrin Heitmann']
+
+description: |
+    This is the 110 sq. deg. extra-galactic catalog covering the ELAIS field for the Roman-Rubin image simulations for LSST DESC that has been created with fully forward modeled SEDs  
+
+include_in_default_catalog_list: true

--- a/GCRCatalogs/catalog_configs/skysim_v3.1.0.yaml
+++ b/GCRCatalogs/catalog_configs/skysim_v3.1.0.yaml
@@ -29,5 +29,5 @@ description: |
 
 include_in_default_catalog_list: false
 
-deprecated: Use roman_rubin_2023_v1.1.1_elais instead.
+deprecated: Use roman_rubin_2023_v1.1.3_elais instead.
 

--- a/GCRCatalogs/catalog_configs/skysim_v3.1.0_image.yaml
+++ b/GCRCatalogs/catalog_configs/skysim_v3.1.0_image.yaml
@@ -17,4 +17,4 @@ sky_area: 439.78986
 description: |
     This is the DC2 image simulation area ofthe extra-galactic catalog for LSST DESC
 
-deprecated: Use roman_rubin_2023_v1.1.1_elais instead.
+deprecated: Use roman_rubin_2023_v1.1.3_elais instead.

--- a/GCRCatalogs/catalog_configs/skysim_v3.1.0_small.yaml
+++ b/GCRCatalogs/catalog_configs/skysim_v3.1.0_small.yaml
@@ -8,4 +8,4 @@ sky_area: 57.071968
 description: |
     This is a small test version of the 440 sq. deg. extra-galactic catalog for LSST-DESC.
 
-deprecated: Use roman_rubin_2023_v1.1.1_elais instead.
+deprecated: Use roman_rubin_2023_v1.1.3_elais instead.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ Confluence page (*DESC member only*).
 #### DiffSky Series
 *by Andrew Hearin, Eve Kovacs, Patricia Larsen, Esteban Rangel, Katrin Heitmann et al.*
 
-- `roman_rubin_v1.1.1_elais`: This catalog was produced for the joint roman-desc image simulations using differentiable, forward modeling techniques. Predictions for the galaxy SEDs are based on their star-formation hsitories. Sky area covers the ELAIS field and is ~110 sq. deg. 
+- `roman_rubin_v1.1.3_elais`: This catalog is a variant of roman_rubin_v1.1.2_elais that uses an improved tuning of the SED model parameters. The resulting luminosity distributions are in better agreement with the validation data (COSMOS 2020 and DESCQA tests). 
+
+- `roman_rubin_v1.1.2_elais`: This catalog was produced for the joint roman-desc image simulations using differentiable, forward modeling techniques. Predictions for the galaxy SEDs are based on their star-formation hsitories. Sky area covers the ELAIS field and is ~110 sq. deg. 
+
+- `roman_rubin_v1.1.1_elais`: DEPRECATED. This catalog was produced for the joint roman-desc image simulations using differentiable, forward modeling techniques. This catalog is deprecated as it contains a serious bug resulting in satellite galaxies that are too bright.
 
 #### SkySim5000
 


### PR DESCRIPTION
Here are the configuration files for the catalog used for the roman-desc simulations  (v_1.1.2) and a newer variant with improved model parameters tuned against Cosmos2020 data.
These catalogs are in the shared catalogs area and the configuration files have been tested with DESCQA. See [ dn/dmag test](https://portal.nersc.gov/cfs/lsst/descqa/v2/?run=2024-01-19)