### PR TITLE
Extend astropy's FlatLambdaCDM

### DIFF
--- a/GCRCatalogs/alphaq.py
+++ b/GCRCatalogs/alphaq.py
@@ -8,8 +8,8 @@ import warnings
 from distutils.version import StrictVersion # pylint: disable=no-name-in-module,import-error
 import numpy as np
 import h5py
-from astropy.cosmology import FlatLambdaCDM
 from GCR import BaseGenericCatalog
+from .cosmology import FlatLambdaCDM
 from .utils import md5, decode
 
 __all__ = ['AlphaQGalaxyCatalog']

--- a/GCRCatalogs/buzzard.py
+++ b/GCRCatalogs/buzzard.py
@@ -7,8 +7,8 @@ import re
 import functools
 import numpy as np
 from astropy.io import fits
-from astropy.cosmology import FlatLambdaCDM
 from GCR import BaseGenericCatalog
+from .cosmology import FlatLambdaCDM
 
 __all__ = ['BuzzardGalaxyCatalog']
 
@@ -61,13 +61,7 @@ class BuzzardGalaxyCatalog(BaseGenericCatalog):
 
         self.cache = dict() if use_cache else None
 
-        cosmo_astropy_allowed = FlatLambdaCDM.__init__.__code__.co_varnames[1:]
-        cosmo_astropy = {k: v for k, v in cosmology.items() if k in cosmo_astropy_allowed}
-        self.cosmology = FlatLambdaCDM(**cosmo_astropy)
-        for k, v in cosmology.items():
-            if k not in cosmo_astropy_allowed:
-                setattr(self.cosmology, k, v)
-
+        self.cosmology = FlatLambdaCDM(**cosmology)
         self.halo_mass_def = halo_mass_def
         self.lightcone = bool(lightcone)
         self.sky_area  = float(sky_area or np.nan)

--- a/GCRCatalogs/cosmodc2.py
+++ b/GCRCatalogs/cosmodc2.py
@@ -12,8 +12,8 @@ import yaml
 import numpy as np
 import h5py
 import healpy as hp
-from astropy.cosmology import FlatLambdaCDM
 from GCR import BaseGenericCatalog
+from .cosmology import FlatLambdaCDM
 from .utils import md5, first, decode
 
 __all__ = ['CosmoDC2GalaxyCatalog', 'BaseDC2GalaxyCatalog', 'BaseDC2SnapshotGalaxyCatalog',
@@ -137,16 +137,9 @@ class CosmoDC2ParentClass(BaseGenericCatalog):
         )
         self._healpix_files = self._file_list # for backward compatibility
 
+        self.cosmology = None
         if 'cosmology' in kwargs:
-            cosmology = kwargs['cosmology']
-            cosmo_astropy_allowed = FlatLambdaCDM.__init__.__code__.co_varnames[1:]
-            cosmo_astropy = {k: v for k, v in cosmology.items() if k in cosmo_astropy_allowed}
-            self.cosmology = FlatLambdaCDM(**cosmo_astropy)
-            for k, v in cosmology.items():
-                if k not in cosmo_astropy_allowed:
-                    setattr(self.cosmology, k, v)
-        else:
-            self.cosmology = None
+            self.cosmology = FlatLambdaCDM(**kwargs['cosmology'])
 
         self.version = kwargs.get('version', '0.0.0')
         if StrictVersion(__version__) < self.version:
@@ -475,7 +468,7 @@ class CosmoDC2GalaxyCatalog(CosmoDC2ParentClass):
                 'LSST_filters/spheroidLuminositiesStellar:LSST_r:rest',
                 'morphology/totalEllipticity',
             ),
-            
+
             'bulge_to_total_ratio_i': (
                 lambda x, y: x/(x+y),
                 'SDSS_filters/spheroidLuminositiesStellar:SDSS_i:observed',
@@ -606,7 +599,7 @@ class SkySim5000GalaxyCatalog(CosmoDC2GalaxyCatalog):
 class DiffSkyGalaxyCatalog(CosmoDC2ParentClass):
     """
     DiffSky galaxy catalog reader, inherited from CosmoDC2ParentClass
-    Class for new generation of catalogs generated with JAX-based 
+    Class for new generation of catalogs generated with JAX-based
     forward modeling techniques.
     This reader is used by the skysim_v3, diffsky and roman_rubin_2023 catalog series
     """
@@ -656,7 +649,7 @@ class DiffSkyGalaxyCatalog(CosmoDC2ParentClass):
         # add magnitudes
         for band in 'ugrizyY':
             if band != 'y' and band != 'Y':
-                quantity_modifiers['mag_{}_sdss'.format(band)] = (_calc_lensed_magnitude, 'SDSS_obs_{}'.format(band), 
+                quantity_modifiers['mag_{}_sdss'.format(band)] = (_calc_lensed_magnitude, 'SDSS_obs_{}'.format(band),
                                                                   'magnification',)
                 quantity_modifiers['mag_true_{}_sdss'.format(band)] = 'SDSS_obs_{}'.format(band.lower())
                 quantity_modifiers['Mag_true_{}_sdss_z0'.format(band)] = 'SDSS_rest_{}'.format(band.upper())
@@ -666,7 +659,7 @@ class DiffSkyGalaxyCatalog(CosmoDC2ParentClass):
                 'magnification',)
                 quantity_modifiers['mag_true_{}_hsc'.format(band)] = 'HSC_obs_{}'.format(band.lower())
                 quantity_modifiers['Mag_true_{}_hsc_z0'.format(band)] = 'HSC_rest_{}'.format(band.upper())
-                
+
             quantity_modifiers['mag_{}_lsst'.format(band)] = (_calc_lensed_magnitude, 'LSST_obs_{}'.format(band.lower(
             )), 'magnification',)
             quantity_modifiers['mag_true_{}_lsst'.format(band)] = 'LSST_obs_{}'.format(band.lower())

--- a/GCRCatalogs/cosmodc2_parquet.py
+++ b/GCRCatalogs/cosmodc2_parquet.py
@@ -4,7 +4,7 @@ For parquet version of cosmoDC2 and skysim5000
 The reader class CosmoDC2ParquetCatalog is the same as DC2TruthParquetCatalog
 but with some metadata processing.
 """
-from astropy.cosmology import FlatLambdaCDM
+from .cosmology import FlatLambdaCDM
 from .dc2_truth_parquet import DC2TruthParquetCatalog
 
 __all__ = ["CosmoDC2ParquetCatalog"]
@@ -20,13 +20,7 @@ class CosmoDC2ParquetCatalog(DC2TruthParquetCatalog):
 
         self.cosmology = None
         if 'cosmology' in kwargs:
-            cosmology = kwargs['cosmology']
-            cosmo_astropy_allowed = FlatLambdaCDM.__init__.__code__.co_varnames[1:]
-            cosmo_astropy = {k: v for k, v in cosmology.items() if k in cosmo_astropy_allowed}
-            self.cosmology = FlatLambdaCDM(**cosmo_astropy)
-            for k, v in cosmology.items():
-                if k not in cosmo_astropy_allowed:
-                    setattr(self.cosmology, k, v)
+            self.cosmology = FlatLambdaCDM(**kwargs['cosmology'])
 
         self.sky_area = None
         if 'sky_area' in kwargs:

--- a/GCRCatalogs/cosmology.py
+++ b/GCRCatalogs/cosmology.py
@@ -1,0 +1,16 @@
+import inspect
+import astropy.cosmology
+
+__all__ = ["FlatLambdaCDM"]
+
+_cosmo_astropy_allowed = inspect.getfullargspec(astropy.cosmology.FlatLambdaCDM).args
+
+class FlatLambdaCDM(astropy.cosmology.FlatLambdaCDM):
+    def __init__(self, **kwargs):
+        cosmo_astropy = dict()
+        for k, v in kwargs.items():
+            if k in _cosmo_astropy_allowed:
+                cosmo_astropy[k] = v
+            else:
+                setattr(self, k, v)
+        super().__init__(**cosmo_astropy)

--- a/GCRCatalogs/instance_catalog.py
+++ b/GCRCatalogs/instance_catalog.py
@@ -9,8 +9,8 @@ import warnings
 from functools import partial
 import numpy as np
 import pandas as pd
-from astropy.cosmology import FlatLambdaCDM
 from GCR import BaseGenericCatalog
+from .cosmology import FlatLambdaCDM
 
 __all__ = ['InstanceCatalog']
 

--- a/GCRCatalogs/photoz.py
+++ b/GCRCatalogs/photoz.py
@@ -76,7 +76,7 @@ class PhotoZCatalog(BaseGenericCatalog):
 
     def _get_quantity_info_dict(self, quantity, default=None):
         return self._info_dict.get(quantity,default)
-    
+
     def _generate_native_quantity_list(self):
         return list(self._quantity_modifiers.values()) + list(self._native_filter_quantities)
 
@@ -143,7 +143,7 @@ class PhotoZCatalog(BaseGenericCatalog):
 
                 slice_this = slice(*meta_patch['slice'])
                 def native_quantity_getter(native_quantity):
-                    # pylint: disable=W0640
+                    # pylint: disable=W0640,E0606
                     # variables (df and slice_this) intentionally defined in loop
                     if native_quantity == '_FULL_PDF':
                         return df.iloc[slice_this, :self._n_pdf_bins].values

--- a/GCRCatalogs/redmagic.py
+++ b/GCRCatalogs/redmagic.py
@@ -3,8 +3,8 @@ redMaGiC catalog class.
 """
 import os
 import functools
-from astropy.cosmology import FlatLambdaCDM
 from GCR import BaseGenericCatalog
+from .cosmology import FlatLambdaCDM
 from .redmapper import FitsFile
 
 __all__ = ['RedmagicCatalog']
@@ -26,13 +26,9 @@ class RedmagicCatalog(BaseGenericCatalog):
         self._catalog_path_template = {k: os.path.join(catalog_root_dir, v) for k, v in catalog_path_template.items()}
         self._file_name = self._catalog_path_template['redmagic']
 
-        cosmology = kwargs.get('cosmology', {})
-        cosmo_astropy_allowed = FlatLambdaCDM.__init__.__code__.co_varnames[1:]
-        cosmo_astropy = {k: v for k, v in cosmology.items() if k in cosmo_astropy_allowed}
-        self.cosmology = FlatLambdaCDM(**cosmo_astropy)
-        for k, v in cosmology.items():
-            if k not in cosmo_astropy_allowed:
-                setattr(self.cosmology, k, v)
+        self.cosmology = None
+        if 'cosmology' in kwargs:
+            self.cosmology = FlatLambdaCDM(**kwargs['cosmology'])
 
         self.lightcone = kwargs.get('lightcone')
         self.sky_area = kwargs.get('sky_area')

--- a/GCRCatalogs/redmapper.py
+++ b/GCRCatalogs/redmapper.py
@@ -5,8 +5,8 @@ from __future__ import division, print_function
 import os
 import functools
 from astropy.io import fits
-from astropy.cosmology import FlatLambdaCDM
 from GCR import BaseGenericCatalog
+from .cosmology import FlatLambdaCDM
 
 __all__ = ['RedmapperCatalog', 'RedMapperLegacyCatalog']
 
@@ -40,13 +40,9 @@ class RedmapperCatalog(BaseGenericCatalog):
 
         self._catalog_path_template = {k: os.path.join(catalog_root_dir, v) for k, v in catalog_path_template.items()}
 
-        cosmology = kwargs.get('cosmology', {})
-        cosmo_astropy_allowed = FlatLambdaCDM.__init__.__code__.co_varnames[1:]
-        cosmo_astropy = {k: v for k, v in cosmology.items() if k in cosmo_astropy_allowed}
-        self.cosmology = FlatLambdaCDM(**cosmo_astropy)
-        for k, v in cosmology.items():
-            if k not in cosmo_astropy_allowed:
-                setattr(self.cosmology, k, v)
+        self.cosmology = None
+        if 'cosmology' in kwargs:
+            self.cosmology = FlatLambdaCDM(**kwargs['cosmology'])
 
         self.lightcone = kwargs.get('lightcone')
         self.sky_area = kwargs.get('sky_area')


### PR DESCRIPTION
This PR introduces a new subclass from astropy's FlatLambdaCDM. The new subclass is identical to FlatLambdaCDM except that it can accept additional attributes, maintaining the original behavior. 

Fix #635 