### PR TITLE
get rid of spurious ".yaml" in alias value

### DIFF
--- a/GCRCatalogs/catalog_configs/dc2_run2.2i_truth_galaxy_summary.yaml
+++ b/GCRCatalogs/catalog_configs/dc2_run2.2i_truth_galaxy_summary.yaml
@@ -1,2 +1,2 @@
-alias: dc2_run2.2i_truth_galaxy_summary_v1-0-0.yaml
+alias: dc2_run2.2i_truth_galaxy_summary_v1-0-0
 include_in_default_catalog_list: true


### PR DESCRIPTION
A one-line fix so that dataregistry can easily parse a now-slightly-nonstandard config file.